### PR TITLE
feat: add -p shorthand for --pr flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ gw add feature/hoge
 gw add -b feature/new
 
 # PR のブランチからワークツリーを作成
-gw add -pr 123
-gw add -pr https://github.com/owner/repo/pull/123
+gw add --pr 123
+gw add -p 123
+gw add --pr https://github.com/owner/repo/pull/123
+gw add -p https://github.com/owner/repo/pull/123
 
 # ワークツリー作成後にエディターで開く（コマンドラインフラグ）
 gw add --open --editor code feature/hoge
@@ -173,7 +175,7 @@ gw sw
 |---------|-----------|------|
 | `gw add <branch>` | `gw a` | ワークツリー作成 |
 | `gw add -b <branch>` | `gw a -b` | 新規ブランチ + ワークツリー作成 |
-| `gw add --pr <url\|number>` | `gw a --pr` | PR ブランチのワークツリー作成 |
+| `gw add --pr <url\|number>` | `gw a --pr`, `gw a -p` | PR ブランチのワークツリー作成 |
 | `gw add --open` | `gw a --open` | ワークツリー作成後にエディターで開く |
 | `gw add --editor <cmd>` | `gw a -e` | 使用するエディターコマンドを指定 |
 | `gw ls` | `gw l` | ワークツリー一覧表示 |

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -50,7 +50,7 @@ func init() {
 	globalConfig = config.LoadOrDefault()
 
 	addCmd.Flags().BoolVarP(&flagAddBranch, "branch", "b", false, "Create a new branch")
-	addCmd.Flags().StringVar(&flagAddPR, "pr", "", "PR number or URL to create worktree for")
+	addCmd.Flags().StringVarP(&flagAddPR, "pr", "p", "", "PR number or URL to create worktree for")
 	addCmd.Flags().BoolVar(&flagAddOpen, "open", false, "Open worktree in editor after creation")
 	addCmd.Flags().StringVarP(&flagEditor, "editor", "e", "", "Editor command to use (e.g., code, vim)")
 	rootCmd.AddCommand(addCmd)

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -46,6 +46,10 @@ func TestAddCmd_PRFlag(t *testing.T) {
 	if flag == nil {
 		t.Fatal("Expected 'pr' flag to be defined")
 	}
+
+	if flag.Shorthand != "p" {
+		t.Errorf("pr flag shorthand = %q, want %q", flag.Shorthand, "p")
+	}
 }
 
 func TestAddCmd_OpenFlag(t *testing.T) {


### PR DESCRIPTION
Closes #10

## 変更内容

\`--pr\` フラグに \`-p\` ショートハンドを追加しました。

## 実装詳細

- \`cmd/add.go\`: \`StringVar\` を \`StringVarP\` に変更し、\`-p\` ショートハンドを追加
- \`cmd/add_test.go\`: \`-p\` ショートハンドの検証テストを追加
- \`README.md\`: ドキュメントを更新し、\`-p\` の使用例を追加

## テスト

- ✅ 全テストがパス
- ✅ Docker 環境でのビルド成功
- ✅ 後方互換性（\`--pr\`）を維持

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-p` as a shorthand alias for the `--pr` flag. Users can now use both `gw add -p <url|number>` and `gw add --pr <url|number>` for PR-based worktree creation.

* **Documentation**
  * Updated README workflow instructions and command reference table to document the new `-p` shorthand alias alongside the existing `--pr` flag for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->