### PR TITLE
fix: use --skip=validate flag for GoReleaser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,4 +84,4 @@ jobs:
             -e HOMEBREW_TAP_GITHUB_TOKEN="${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}" \
             gw-release:latest sh -c '\
             git config --global --add safe.directory /workspace && \
-            goreleaser release --clean --release-notes /workspace/RELEASE_NOTES.md'
+            goreleaser release --clean --skip=validate --release-notes /workspace/RELEASE_NOTES.md'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,13 +34,6 @@ changelog:
   # Disable built-in changelog generation (use git-cliff instead)
   disable: true
 
-git:
-  # Allow dirty state since we generate RELEASE_NOTES.md during CI
-  ignore_tags:
-    - "*"
-  # Skip validation to allow untracked RELEASE_NOTES.md
-  allow_dirty: true
-
 brews:
   - repository:
       owner: t98o84


### PR DESCRIPTION
## Problem

The previous attempt to use \`git.allow_dirty: true\` in .goreleaser.yaml failed because this field doesn't exist in GoReleaser v2:

\`\`\`
error=yaml: unmarshal errors:
line 42: field allow_dirty not found in type config.Git
\`\`\`

## Solution

Use the \`--skip=validate\` command-line flag instead, which is the correct way to skip git state validation in GoReleaser v2.

### Changes:
1. Removed \`git\` section from \`.goreleaser.yaml\`
2. Added \`--skip=validate\` flag to the goreleaser command in CI workflow

This flag skips all validation checks, including git dirty state checks, allowing the release to proceed with the generated RELEASE_NOTES.md file.

## Testing

Will be tested by re-creating v0.4.0 tag after merge.

## Related

- Failed run: https://github.com/t98o84/gw/actions/runs/20521679932
- GoReleaser docs: https://goreleaser.com/cmd/goreleaser_release/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow GoReleaser configuration to skip validation checks during releases
  * Removed release configuration settings that bypassed tag validation and allowed dirty repository states, implementing stricter git state requirements for releases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->