### PR TITLE
fix: run post_add/pre_remove hooks inside the worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ hooks:
   
   # Before worktree deletion
   pre_remove:
-    # Backup data
+    # Backup data (pre_remove runs inside the worktree that is about to be
+    # removed, so write the archive to the repo root to keep it)
     - command: |
         echo "Backing up data from $GW_WORKTREE_PATH"
-        tar -czf "backup-$GW_BRANCH-$(date +%Y%m%d).tar.gz" -C "$GW_WORKTREE_PATH" .
+        tar -czf "$GW_REPO_ROOT/backup-$GW_BRANCH-$(date +%Y%m%d).tar.gz" .
   
   # After worktree deletion
   post_remove:
@@ -192,6 +193,15 @@ hooks:
 ```
 
 You can also add custom environment variables in the `env` field (and even override gw's environment variables).
+
+#### Working Directory
+
+Each hook runs in a working directory that matches its point in the worktree lifecycle:
+
+- **post_add / pre_remove**: run inside the target worktree (`$GW_WORKTREE_PATH`), since it exists at that point. For example, `post_add: cp .env.example .env` copies the file into the new worktree.
+- **pre_add / post_remove**: run in the main repository root (`$GW_REPO_ROOT`), because the worktree does not exist yet (`pre_add`) or has already been removed (`post_remove`).
+
+Because absolute paths (`$GW_WORKTREE_PATH`, `$GW_REPO_ROOT`) are always available, you can operate on either location from any hook regardless of the working directory.
 
 #### Hook Execution Order and Error Handling
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -43,7 +43,11 @@ Hooks:
     - GW_WORKTREE_PATH: Path to the worktree
     - GW_BRANCH: Branch name
     - GW_REPO_ROOT: Repository root path
-  
+
+  Working directory:
+    - pre_add runs in the repository root (worktree not created yet)
+    - post_add runs inside the new worktree (GW_WORKTREE_PATH)
+
   Example gw.yaml:
     hooks:
       pre_add:
@@ -51,7 +55,7 @@ Hooks:
           command: echo "Creating worktree for $GW_BRANCH"
       post_add:
         - name: "Install dependencies"
-          command: cd "$GW_WORKTREE_PATH" && npm install
+          command: npm install
 
 Examples:
   gw add feature/hoge

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -39,14 +39,19 @@ Hooks:
     - GW_WORKTREE_PATH: Path to the worktree
     - GW_BRANCH: Branch name
     - GW_REPO_ROOT: Repository root path
-  
+
+  Working directory:
+    - pre_remove runs inside the worktree (GW_WORKTREE_PATH); write any output
+      you want to keep to GW_REPO_ROOT, since the worktree is removed next
+    - post_remove runs in the repository root (worktree already removed)
+
   Example gw.yaml:
     hooks:
       pre_remove:
         - name: "Backup data"
           command: |
             echo "Backing up data from $GW_WORKTREE_PATH"
-            tar -czf "backup-$GW_BRANCH.tar.gz" "$GW_WORKTREE_PATH"
+            tar -czf "$GW_REPO_ROOT/backup-$GW_BRANCH.tar.gz" .
       post_remove:
         - name: "Clean up artifacts"
           command: echo "Cleaned up worktree for $GW_BRANCH"

--- a/examples/gw.yaml
+++ b/examples/gw.yaml
@@ -55,9 +55,11 @@ hooks:
   # Hooks executed before worktree removal
   pre_remove:
     # Example 1: Backup important data
+    # pre_remove runs inside the worktree, which is about to be removed,
+    # so write the archive to the repo root ($GW_REPO_ROOT) to keep it.
     - command: |
         echo "Backing up data from $GW_WORKTREE_PATH"
-        tar -czf "backup-$GW_BRANCH-$(date +%Y%m%d).tar.gz" -C "$GW_WORKTREE_PATH" .
+        tar -czf "$GW_REPO_ROOT/backup-$GW_BRANCH-$(date +%Y%m%d).tar.gz" .
     
     # Example 2: Stop running services
     - command: |
@@ -94,7 +96,10 @@ hooks:
 #
 # Notes:
 # - Hooks are executed in the order they are defined
-# - Commands are executed in the worktree directory (or repo root for pre_add)
+# - Working directory of each hook:
+#     - post_add, pre_remove: the target worktree directory ($GW_WORKTREE_PATH)
+#     - pre_add (worktree not yet created), post_remove (worktree already
+#       removed): the main repository root ($GW_REPO_ROOT)
 # - If a pre_add or pre_remove hook fails, the operation is aborted
 # - If a post_add or post_remove hook fails, a warning is displayed but the operation continues
 # - Use multiline commands with | for complex scripts

--- a/internal/config/hooks.go
+++ b/internal/config/hooks.go
@@ -40,8 +40,15 @@ func ExecuteHooks(projectConfig *ProjectConfig, hookType HookType, worktreePath,
 		return nil
 	}
 
+	// Determine the working directory for the hook commands.
+	// post_add and pre_remove run inside the target worktree, since it exists
+	// at that point and is the natural place to operate on. pre_add (worktree
+	// not yet created) and post_remove (worktree already deleted) run in the
+	// main repository root.
+	workDir := hookWorkDir(hookType, worktreePath, repoRoot)
+
 	for i, hook := range hooks {
-		if err := executeHook(hook, worktreePath, branch, repoRoot, i); err != nil {
+		if err := executeHook(hook, workDir, worktreePath, branch, repoRoot, i); err != nil {
 			return fmt.Errorf("hook %d failed: %w", i+1, err)
 		}
 	}
@@ -49,11 +56,21 @@ func ExecuteHooks(projectConfig *ProjectConfig, hookType HookType, worktreePath,
 	return nil
 }
 
-func executeHook(hook Hook, worktreePath, branch, repoRoot string, index int) error {
-	return executeCommandHook(hook, worktreePath, branch, repoRoot, index)
+// hookWorkDir returns the directory in which a hook's command should run.
+func hookWorkDir(hookType HookType, worktreePath, repoRoot string) string {
+	switch hookType {
+	case HookPostAdd, HookPreRemove:
+		return worktreePath
+	default: // HookPreAdd, HookPostRemove
+		return repoRoot
+	}
 }
 
-func executeCommandHook(hook Hook, worktreePath, branch, repoRoot string, index int) error {
+func executeHook(hook Hook, workDir, worktreePath, branch, repoRoot string, index int) error {
+	return executeCommandHook(hook, workDir, worktreePath, branch, repoRoot, index)
+}
+
+func executeCommandHook(hook Hook, workDir, worktreePath, branch, repoRoot string, index int) error {
 	if hook.Command == "" {
 		return fmt.Errorf("command hook requires 'command' field")
 	}
@@ -61,7 +78,7 @@ func executeCommandHook(hook Hook, worktreePath, branch, repoRoot string, index 
 	fmt.Printf("⚙️  Hook %d: Executing command: %s\n", index+1, hook.Command)
 
 	cmd := exec.Command("sh", "-c", hook.Command)
-	cmd.Dir = repoRoot
+	cmd.Dir = workDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/internal/config/hooks_test.go
+++ b/internal/config/hooks_test.go
@@ -108,7 +108,8 @@ func TestExecuteHooks(t *testing.T) {
 			},
 			expectError: false,
 			validateFunc: func(t *testing.T, worktreePath string, repoRoot string) {
-				content, err := os.ReadFile(filepath.Join(repoRoot, "env_test.txt"))
+				// post_add hooks run inside the worktree directory.
+				content, err := os.ReadFile(filepath.Join(worktreePath, "env_test.txt"))
 				if err != nil {
 					t.Errorf("failed to read command output: %v", err)
 					return
@@ -229,6 +230,59 @@ echo "Line 3" >> output.txt`,
 	}
 }
 
+func TestExecuteHooksWorkingDirectory(t *testing.T) {
+	tests := []struct {
+		name     string
+		hookType HookType
+		// wantDir selects which of the two directories the hook is expected to
+		// run in: "worktree" or "repo".
+		wantDir string
+	}{
+		{name: "post_add runs in worktree", hookType: HookPostAdd, wantDir: "worktree"},
+		{name: "pre_remove runs in worktree", hookType: HookPreRemove, wantDir: "worktree"},
+		{name: "pre_add runs in repo root", hookType: HookPreAdd, wantDir: "repo"},
+		{name: "post_remove runs in repo root", hookType: HookPostRemove, wantDir: "repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			worktreePath := t.TempDir()
+			repoRoot := t.TempDir()
+
+			// The hook writes a marker file into its current working directory.
+			hook := Hook{Command: "pwd > marker.txt"}
+			cfg := &ProjectConfig{}
+			switch tt.hookType {
+			case HookPreAdd:
+				cfg.Hooks.PreAdd = []Hook{hook}
+			case HookPostAdd:
+				cfg.Hooks.PostAdd = []Hook{hook}
+			case HookPreRemove:
+				cfg.Hooks.PreRemove = []Hook{hook}
+			case HookPostRemove:
+				cfg.Hooks.PostRemove = []Hook{hook}
+			}
+
+			if err := ExecuteHooks(cfg, tt.hookType, worktreePath, "feature/test", repoRoot); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			wantDir := repoRoot
+			otherDir := worktreePath
+			if tt.wantDir == "worktree" {
+				wantDir, otherDir = worktreePath, repoRoot
+			}
+
+			if _, err := os.Stat(filepath.Join(wantDir, "marker.txt")); err != nil {
+				t.Errorf("expected marker.txt in %s (%s), but it was not created: %v", tt.wantDir, wantDir, err)
+			}
+			if _, err := os.Stat(filepath.Join(otherDir, "marker.txt")); err == nil {
+				t.Errorf("marker.txt was unexpectedly created in the other directory: %s", otherDir)
+			}
+		})
+	}
+}
+
 func TestExecuteCommandHook(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -264,7 +318,7 @@ func TestExecuteCommandHook(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			err := executeCommandHook(tt.hook, dir, "test-branch", dir, 0)
+			err := executeCommandHook(tt.hook, dir, dir, "test-branch", dir, 0)
 
 			if tt.expectError {
 				if err == nil {


### PR DESCRIPTION
## 概要

`post_add` / `pre_remove` フックの作業ディレクトリを、対象の worktree (`GW_WORKTREE_PATH`) に変更します。`pre_add`（worktree 未作成）/ `post_remove`（worktree 削除済み）は従来どおりリポジトリルート (`GW_REPO_ROOT`) で実行します。

これまでは全フックがリポジトリルートで実行され、`examples/gw.yaml` の説明「Commands are executed in the worktree directory」および `post_add: cp .env.example .env` のような例と挙動が矛盾していました（新 worktree ではなくメインリポジトリ側で動作していた）。

Closes #35

## 変更点

### 実装 (`internal/config/hooks.go`)
- フック種別ごとに作業ディレクトリを決める `hookWorkDir` を追加し、`cmd.Dir` に反映
  - `post_add` / `pre_remove` → worktree
  - `pre_add` / `post_remove` → repo root
- `GW_*` 環境変数は全種別で従来どおり利用可能（挙動不変）

### テスト (`internal/config/hooks_test.go`)
- 追加: `TestExecuteHooksWorkingDirectory` — 4 種別すべてで、正しい方のディレクトリにのみコマンドの CWD が設定されることを検証
- 既存テストを新シグネチャ・新挙動に追従

### ドキュメント
- `examples/gw.yaml` / `README.md` / `cmd/add.go` / `cmd/rm.go` の作業ディレクトリ説明を正確化
- `pre_remove` は削除直前の worktree 内で実行されるため、バックアップ例の出力先を相対パスから `$GW_REPO_ROOT/...` に変更（相対パスだと成果物ごと削除される落とし穴を回避）

## 後方互換への注意

これは挙動変更です。`post_add` / `pre_remove` をリポジトリルート前提で書いていた既存フックは影響を受けます。ルート側で操作したい場合は `$GW_REPO_ROOT` を明示してください（絶対パスは全フックで常に利用可能）。

## 検証

Docker 環境で以下を実行し、いずれも成功:
- `gofmt -l`（差分なし）
- `go build ./...`
- `go test ./...`（全パッケージ PASS）