### PR TITLE
fix: allow hook env to override gw-provided variables (GW_*)

### DIFF
--- a/internal/config/hooks.go
+++ b/internal/config/hooks.go
@@ -65,18 +65,20 @@ func executeCommandHook(hook Hook, worktreePath, branch, repoRoot string, index 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	// Set environment variables with gw-specific variables
+	// Set environment variables.
 	cmd.Env = os.Environ()
-	// Add user-defined environment variables first
-	for key, value := range hook.Env {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
-	}
-	// Add gw-specific environment variables (these take precedence)
+	// Add gw-specific environment variables first, as defaults.
 	cmd.Env = append(cmd.Env,
 		fmt.Sprintf("GW_WORKTREE_PATH=%s", worktreePath),
 		fmt.Sprintf("GW_BRANCH=%s", branch),
 		fmt.Sprintf("GW_REPO_ROOT=%s", repoRoot),
 	)
+	// Add user-defined environment variables last so they take precedence.
+	// os/exec dedups duplicate keys with a last-one-wins rule, so a user can
+	// override gw-provided variables (GW_*) by setting them in the env field.
+	for key, value := range hook.Env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("command execution failed: %w", err)

--- a/internal/config/hooks_test.go
+++ b/internal/config/hooks_test.go
@@ -126,6 +126,37 @@ func TestExecuteHooks(t *testing.T) {
 			},
 		},
 		{
+			name: "user env overrides gw environment variables",
+			setupFunc: func() (string, *ProjectConfig, string, string) {
+				dir := t.TempDir()
+				cfg := &ProjectConfig{
+					Hooks: HooksConfig{
+						PostAdd: []Hook{
+							{
+								Command: "echo \"$GW_BRANCH\" > override_test.txt",
+								Env: map[string]string{
+									"GW_BRANCH": "OVERRIDDEN",
+								},
+							},
+						},
+					},
+				}
+				return dir, cfg, "feature/test", dir
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, worktreePath string, repoRoot string) {
+				content, err := os.ReadFile(filepath.Join(repoRoot, "override_test.txt"))
+				if err != nil {
+					t.Errorf("failed to read command output: %v", err)
+					return
+				}
+				output := strings.TrimSpace(string(content))
+				if output != "OVERRIDDEN" {
+					t.Errorf("expected user env to override GW_BRANCH, got: %s", output)
+				}
+			},
+		},
+		{
 			name: "multiple hooks",
 			setupFunc: func() (string, *ProjectConfig, string, string) {
 				dir := t.TempDir()


### PR DESCRIPTION
## 概要
issue #37 の対応。フックの `env` で gw 提供の環境変数（`GW_WORKTREE_PATH` / `GW_BRANCH` / `GW_REPO_ROOT`）を上書きできない、ドキュメントとの矛盾を解消する。

## 方針
issue で示された2案のうち、**実装を修正（`env` 後勝ち）** を採用。README・`examples/gw.yaml` の両方が「custom env で gw 変数を上書き可能」と明記しており、これを正とした。ドキュメントは既に正しい記述のため変更不要。

## 変更内容
- `internal/config/hooks.go`: `cmd.Env` への追加順を入れ替え、gw 変数を先（デフォルト）、ユーザー定義 `env` を後に append。`os/exec` の重複キー last-one-wins により、ユーザー `env` が優先される。
- `internal/config/hooks_test.go`: `GW_BRANCH` をユーザー `env` で上書きし `OVERRIDDEN` になることを検証するテストケースを追加（issue の再現シナリオと一致）。

## 検証
- `go test ./...` 全 PASS（`-race` 含む）
- `go vet` / `gofmt` クリーン
- golangci-lint: 変更ファイルは指摘なし（既存の `loader_test.go:97` errcheck は本 PR 対象外）

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User-defined hook environment variables now take precedence over automatically provided `GW_*` values, making hook behavior more predictable.
  * Fixed cases where duplicate environment variables could override user settings unexpectedly.
* **Tests**
  * Added coverage to verify that hook environment overrides work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->