### PR TITLE
fix: close.force で shell wrapper が失敗する問題の修正 + close の -b/--branch 実装 + force フラグのドキュメント整合 (#34, #36, #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ add:
   sync_ignored: false  # Also sync gitignored files
 rm:
   branch: false  # Also delete branch when removing worktree
-  force: false  # Skip confirmation prompt
+  force: false  # Force removal of dirty/locked worktrees (and unmerged branches with -b)
 close:
-  force: false  # Skip confirmation prompt
+  force: false  # Force removal of dirty/locked worktrees (and unmerged branches with -b)
 editor: code  # Editor command to use
 ```
 
@@ -279,8 +279,8 @@ editor: code  # Editor command to use
 - `add.sync` (boolean): Whether to sync files from main worktree (default: `false`)
 - `add.sync_ignored` (boolean): Whether to also sync gitignored files (default: `false`)
 - `rm.branch` (boolean): Whether to also delete associated branch when removing worktree (default: `false`)
-- `rm.force` (boolean): Whether to skip confirmation prompt when deleting (default: `false`)
-- `close.force` (boolean): Whether to skip confirmation prompt when closing (default: `false`)
+- `rm.force` (boolean): Whether to force removal of dirty/locked worktrees and unmerged branches, passing `--force` to `git worktree remove` (and `git branch -D`). There is no interactive confirmation prompt (default: `false`)
+- `close.force` (boolean): Whether to force removal when closing; forwarded to `gw rm` as `-y` (default: `false`)
 - `editor` (string): Editor command to use (e.g., `code`, `vim`, `emacs`)
 
 **Note**: Flag precedence is as follows: `--no-*` flags > regular flags > configuration file
@@ -292,7 +292,7 @@ You can disable options enabled in the configuration file when executing command
 - `--no-open`: Don't open even with `add.open=true`
 - `--no-sync`: Don't sync even with `add.sync=true`
 - `--no-sync-ignored`: Don't sync gitignored files even with `add.sync_ignored=true`
-- `--no-yes` / `--no-force`: Show confirmation prompt even with `close.force=true` or `rm.force=true`
+- `--no-yes` / `--no-force`: Disable force removal even with `close.force=true` or `rm.force=true`
 - `--no-branch`: Don't delete branch even with `rm.branch=true`
 
 ```bash
@@ -407,7 +407,7 @@ gw sw
 # Close current worktree and return to main worktree
 gw close
 
-# Skip confirmation prompt and close
+# Force removal (dirty/locked worktree) and close
 gw close -y
 gw close --yes
 
@@ -422,7 +422,7 @@ gw close -f -b
 **Note**: The `gw close` command:
 - Cannot be executed from main worktree (`main` or `master`)
 - Requires shell integration (setup with `gw init` required)
-- Can skip confirmation prompt by setting `close.force=true` in config file
+- Can force removal of dirty/locked worktrees by setting `close.force=true` in config file
 
 ## Command List
 
@@ -445,14 +445,14 @@ gw close -f -b
 | `gw rm` | `gw r` | Select with fzf (no arguments, Tab for multiple) |
 | `gw rm -b <name>` | `gw r -b` | Remove worktree and branch |
 | `gw rm --no-branch <name>` | `gw r --no-branch` | Don't delete branch (ignore config) |
-| `gw rm --yes/-y` | `gw r -y` | Skip confirmation prompt |
-| `gw rm --no-yes/--no-force` | `gw r --no-yes` | Show confirmation prompt (ignore config) |
+| `gw rm --yes/-y` | `gw r -y` | Force removal of dirty/locked worktree |
+| `gw rm --no-yes/--no-force` | `gw r --no-yes` | Disable force removal (ignore config) |
 | `gw exec [name] <cmd...>` | `gw e` | Execute command in target worktree (fzf without arguments) |
 | `gw sw [name]` | `gw s` | Navigate to target worktree (fzf without arguments) |
 | `gw close [flags]` | `gw c` | Close current worktree and return to main |
 | `gw close -b` | `gw c -b` | Close and delete worktree and branch |
-| `gw close -y/--yes` | `gw c -y` | Close and skip confirmation prompt |
-| `gw close --no-yes/--no-force` | `gw c --no-yes` | Show confirmation prompt (ignore config) |
+| `gw close -y/--yes` | `gw c -y` | Close and force removal of dirty/locked worktree |
+| `gw close --no-yes/--no-force` | `gw c --no-yes` | Disable force removal (ignore config) |
 | `gw fd` | `gw f` | Search worktrees with fzf (output branch name) |
 | `gw fd -p` | `gw f -p` | Search worktrees with fzf (output full path) |
 | `gw init <shell>` | `gw i` | Output shell initialization script |

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can disable options enabled in the configuration file when executing command
 - `--no-open`: Don't open even with `add.open=true`
 - `--no-sync`: Don't sync even with `add.sync=true`
 - `--no-sync-ignored`: Don't sync gitignored files even with `add.sync_ignored=true`
-- `--no-yes` / `--no-force`: Disable force removal even with `close.force=true` or `rm.force=true`
+- `--no-yes` / `--no-force`: Disable force removal for the command it is passed to. `gw rm --no-yes` overrides `rm.force=true`; `gw close --no-yes` overrides `close.force=true` (it is not forwarded to `gw rm`, so a separately configured `rm.force=true` still applies)
 - `--no-branch`: Don't delete branch even with `rm.branch=true`
 
 ```bash

--- a/cmd/close.go
+++ b/cmd/close.go
@@ -16,6 +16,7 @@ var closeConfig = struct {
 	PrintPath bool
 	Yes       bool
 	Force     bool
+	Branch    bool
 	NoYes     bool
 	NoForce   bool
 }{}
@@ -33,7 +34,9 @@ This command must be run from within a non-main worktree. It will:
 Note: This command requires shell integration. Run 'gw init <shell>' to set up.
 
 Examples:
-  gw close       # Close current worktree and switch to main`,
+  gw close          # Close current worktree and switch to main
+  gw close -b       # Also delete the associated branch
+  gw close -f -b    # Force close and delete an unmerged branch`,
 	Args: cobra.NoArgs,
 	RunE: runClose,
 }
@@ -41,7 +44,8 @@ Examples:
 func init() {
 	closeCmd.Flags().BoolVar(&closeConfig.PrintPath, "print-path", false, "Print the path instead of changing directory (used by shell wrapper)")
 	closeCmd.Flags().BoolVarP(&closeConfig.Yes, "yes", "y", false, "Force worktree removal even if dirty (forwarded to gw rm by the shell wrapper)")
-	closeCmd.Flags().BoolVar(&closeConfig.Force, "force", false, "Alias for --yes")
+	closeCmd.Flags().BoolVarP(&closeConfig.Force, "force", "f", false, "Alias for --yes")
+	closeCmd.Flags().BoolVarP(&closeConfig.Branch, "branch", "b", false, "Also delete the associated git branch (forwarded to gw rm by the shell wrapper)")
 	closeCmd.Flags().BoolVar(&closeConfig.NoYes, "no-yes", false, "Disable force removal (overrides config and --yes)")
 	closeCmd.Flags().BoolVar(&closeConfig.NoForce, "no-force", false, "Alias for --no-yes")
 	rootCmd.AddCommand(closeCmd)
@@ -109,24 +113,47 @@ func runClose(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get main worktree path: %w", err)
 	}
 
+	// Determine the flags to forward to 'gw rm' via the shell wrapper.
+	// Force (-y) forces removal of a dirty worktree and deletion of an
+	// unmerged branch; branch (-b) also deletes the associated git branch.
+	yesFlag := ""
+	if mergedConfig.Close.Force {
+		yesFlag = "-y"
+	}
+	branchFlag := ""
+	if closeConfig.Branch {
+		branchFlag = "-b"
+	}
+
 	if closeConfig.PrintPath {
 		// Print the main worktree path for shell wrapper to use (stdout)
 		fmt.Println(mainPath)
 		// Print the current worktree path on stderr for the shell wrapper to remove
 		fmt.Fprintf(os.Stderr, "%s\n", currentWT.Path)
-		// Print -y flag status on stderr (second line)
-		if mergedConfig.Close.Force {
-			fmt.Fprintf(os.Stderr, "-y\n")
-		} else {
-			fmt.Fprintf(os.Stderr, "\n")
-		}
+		// Print the flags to forward to 'gw rm' on their own stderr lines
+		// (line 2 = force, line 3 = branch). Keeping each flag on a separate
+		// line lets the wrapper forward them without word-splitting a joined
+		// string, which zsh does not do by default.
+		fmt.Fprintf(os.Stderr, "%s\n", yesFlag)
+		fmt.Fprintf(os.Stderr, "%s\n", branchFlag)
 		return nil
 	}
 
 	// Without shell integration, we can't actually change directory
 	// Print instructions
+	var rmFlags []string
+	if yesFlag != "" {
+		rmFlags = append(rmFlags, yesFlag)
+	}
+	if branchFlag != "" {
+		rmFlags = append(rmFlags, branchFlag)
+	}
+	rmInvocation := "gw rm"
+	if len(rmFlags) > 0 {
+		rmInvocation += " " + strings.Join(rmFlags, " ")
+	}
 	fmt.Fprintf(os.Stderr, "To close this worktree and switch to main, run:\n")
-	fmt.Fprintf(os.Stderr, "  cd %s && gw rm %s\n\n", mainPath, currentWT.Path)
+	fmt.Fprintf(os.Stderr, "  cd %s && %s %s\n\n", mainPath, rmInvocation, currentWT.Path)
 	fmt.Fprintf(os.Stderr, "For automatic directory switching and worktree removal, set up shell integration:\n")
 	fmt.Fprintf(os.Stderr, "  eval \"$(gw init bash)\"   # for bash\n")
 	fmt.Fprintf(os.Stderr, "  eval \"$(gw init zsh)\"    # for zsh\n")

--- a/cmd/close.go
+++ b/cmd/close.go
@@ -40,9 +40,9 @@ Examples:
 
 func init() {
 	closeCmd.Flags().BoolVar(&closeConfig.PrintPath, "print-path", false, "Print the path instead of changing directory (used by shell wrapper)")
-	closeCmd.Flags().BoolVarP(&closeConfig.Yes, "yes", "y", false, "Automatically confirm worktree deletion (used by shell wrapper)")
+	closeCmd.Flags().BoolVarP(&closeConfig.Yes, "yes", "y", false, "Force worktree removal even if dirty (forwarded to gw rm by the shell wrapper)")
 	closeCmd.Flags().BoolVar(&closeConfig.Force, "force", false, "Alias for --yes")
-	closeCmd.Flags().BoolVar(&closeConfig.NoYes, "no-yes", false, "Force disable automatic confirmation (overrides config and --yes)")
+	closeCmd.Flags().BoolVar(&closeConfig.NoYes, "no-yes", false, "Disable force removal (overrides config and --yes)")
 	closeCmd.Flags().BoolVar(&closeConfig.NoForce, "no-force", false, "Alias for --no-yes")
 	rootCmd.AddCommand(closeCmd)
 }

--- a/cmd/close_test.go
+++ b/cmd/close_test.go
@@ -1,6 +1,11 @@
 package cmd
 
 import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/t98o84/gw/internal/git"
@@ -60,6 +65,33 @@ func TestCloseCmd_ForceFlag(t *testing.T) {
 	flag := closeCmd.Flags().Lookup("force")
 	if flag == nil {
 		t.Fatal("Expected 'force' flag to be defined")
+	}
+}
+
+func TestCloseCmd_ForceFlagShorthand(t *testing.T) {
+	flag := closeCmd.Flags().Lookup("force")
+	if flag == nil {
+		t.Fatal("Expected 'force' flag to be defined")
+	}
+	if flag.Shorthand != "f" {
+		t.Errorf("Expected shorthand 'f', got '%s'", flag.Shorthand)
+	}
+}
+
+func TestCloseCmd_BranchFlag(t *testing.T) {
+	flag := closeCmd.Flags().Lookup("branch")
+	if flag == nil {
+		t.Fatal("Expected 'branch' flag to be defined")
+	}
+}
+
+func TestCloseCmd_BranchFlagShorthand(t *testing.T) {
+	flag := closeCmd.Flags().Lookup("branch")
+	if flag == nil {
+		t.Fatal("Expected 'branch' flag to be defined")
+	}
+	if flag.Shorthand != "b" {
+		t.Errorf("Expected shorthand 'b', got '%s'", flag.Shorthand)
 	}
 }
 
@@ -141,4 +173,157 @@ func TestFindCurrentWorktree(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunClose_PrintPathProtocol drives runClose against a real git worktree and
+// verifies the --print-path protocol the shell wrapper relies on: stdout carries
+// the main worktree path, and stderr carries the worktree path (line 1), the
+// force flag (line 2) and the branch flag (line 3). This exercises the core
+// flag-forwarding behaviour of issue #36 end to end.
+func TestRunClose_PrintPathProtocol(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Isolate config so a user's ~/.config/gw/config.yaml can't flip close.force.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// EvalSymlinks so paths match what git reports (e.g. /var -> /private/var on macOS).
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repo, "init", "-q", "-b", "main")
+	gitCmd(t, repo, "commit", "-q", "--allow-empty", "-m", "init")
+	wt := filepath.Join(root, "wt")
+	gitCmd(t, repo, "worktree", "add", "-q", wt, "-b", "feature")
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWd)
+		resetCloseFlags(t)
+	})
+	if err := os.Chdir(wt); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		yes        bool
+		branch     bool
+		wantForce  string
+		wantBranch string
+	}{
+		{"no flags", false, false, "", ""},
+		{"force only", true, false, "-y", ""},
+		{"branch only", false, true, "", "-b"},
+		{"force and branch", true, true, "-y", "-b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetCloseFlags(t)
+			mustSetFlag(t, "print-path", "true")
+			if tt.yes {
+				mustSetFlag(t, "yes", "true")
+			}
+			if tt.branch {
+				mustSetFlag(t, "branch", "true")
+			}
+
+			stdout, stderr := captureStdoutStderr(t, func() {
+				if err := runClose(closeCmd, nil); err != nil {
+					t.Fatalf("runClose returned error: %v", err)
+				}
+			})
+
+			if gotMain := strings.TrimSpace(stdout); gotMain != repo {
+				t.Errorf("stdout main path = %q, want %q", gotMain, repo)
+			}
+
+			lines := strings.Split(strings.TrimRight(stderr, "\n"), "\n")
+			if lineAt(lines, 0) != wt {
+				t.Errorf("stderr line 1 (worktree path) = %q, want %q", lineAt(lines, 0), wt)
+			}
+			if got := lineAt(lines, 1); got != tt.wantForce {
+				t.Errorf("stderr line 2 (force flag) = %q, want %q", got, tt.wantForce)
+			}
+			if got := lineAt(lines, 2); got != tt.wantBranch {
+				t.Errorf("stderr line 3 (branch flag) = %q, want %q", got, tt.wantBranch)
+			}
+		})
+	}
+}
+
+// lineAt returns lines[i] or "" when the index is out of range (trailing empty
+// protocol lines are dropped by TrimRight).
+func lineAt(lines []string, i int) string {
+	if i < len(lines) {
+		return lines[i]
+	}
+	return ""
+}
+
+func mustSetFlag(t *testing.T, name, value string) {
+	t.Helper()
+	if err := closeCmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("set flag %s=%s: %v", name, value, err)
+	}
+}
+
+func resetCloseFlags(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"print-path", "yes", "force", "branch", "no-yes", "no-force"} {
+		if err := closeCmd.Flags().Set(name, "false"); err != nil {
+			t.Fatalf("reset flag %s: %v", name, err)
+		}
+	}
+}
+
+func gitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+// captureStdoutStderr swaps os.Stdout/os.Stderr for pipes while fn runs and
+// returns what was written. Output is expected to be small (well under the pipe
+// buffer), so reading after fn returns cannot deadlock.
+func captureStdoutStderr(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout, os.Stderr = outW, errW
+	defer func() { os.Stdout, os.Stderr = origOut, origErr }()
+
+	fn()
+
+	_ = outW.Close()
+	_ = errW.Close()
+	outBytes, _ := io.ReadAll(outR)
+	errBytes, _ := io.ReadAll(errR)
+	return string(outBytes), string(errBytes)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -51,13 +51,32 @@ gw() {
       cd "$target"
     fi
   elif [ "$1" = "close" ] || [ "$1" = "c" ]; then
-    # Capture stderr (worktree path) and stdout (main path) separately
-    local worktree_to_remove target
-    worktree_to_remove="$(command gw close --print-path 2>&1 >/dev/null)"
-    target="$(command gw close --print-path 2>/dev/null)"
-    
-    if [ -n "$target" ] && [ -n "$worktree_to_remove" ]; then
-      cd "$target" && command gw rm "$worktree_to_remove"
+    # Forward only the force flags that 'gw close' understands; other args
+    # (e.g. -b) are ignored so they don't trigger an unknown-flag error.
+    local has_yes="" has_no="" close_arg="" arg
+    for arg in "${@:2}"; do
+      case "$arg" in
+        -y|--yes|--force) has_yes=1 ;;
+        --no-yes|--no-force) has_no=1 ;;
+      esac
+    done
+    if [ -n "$has_no" ]; then close_arg="--no-yes"; elif [ -n "$has_yes" ]; then close_arg="-y"; fi
+
+    # Capture stderr (worktree path and -y flag) and stdout (main path) separately
+    local stderr_output main_path worktree_to_remove yes_flag
+    stderr_output="$(command gw close --print-path $close_arg 2>&1 >/dev/null)"
+    main_path="$(command gw close --print-path $close_arg 2>/dev/null)"
+
+    # Parse stderr output: line 1 = worktree path, line 2 = -y flag
+    worktree_to_remove="$(sed -n '1p' <<< "$stderr_output")"
+    yes_flag="$(sed -n '2p' <<< "$stderr_output")"
+
+    if [ -n "$main_path" ] && [ -n "$worktree_to_remove" ]; then
+      if [ "$yes_flag" = "-y" ]; then
+        cd "$main_path" && command gw rm -y "$worktree_to_remove"
+      else
+        cd "$main_path" && command gw rm "$worktree_to_remove"
+      fi
     fi
   else
     command gw "$@"
@@ -73,14 +92,37 @@ function gw
       cd "$target"
     end
   else if test "$argv[1]" = "close" -o "$argv[1]" = "c"
-    # Capture stderr (worktree path and -y flag) and stdout (main path)
-    set -l stderr_output (command gw close --print-path 2>&1 >/dev/null)
-    set -l main_path (command gw close --print-path 2>/dev/null)
-    
-    # Parse stderr output: line 1 = worktree path, line 2 = -y flag
-    set -l worktree_to_remove (echo "$stderr_output" | sed -n '1p')
-    set -l yes_flag (echo "$stderr_output" | sed -n '2p')
-    
+    # Forward only the force flags that 'gw close' understands; other args
+    # (e.g. -b) are ignored so they don't trigger an unknown-flag error.
+    set -l has_yes 0
+    set -l has_no 0
+    for a in $argv[2..]
+      switch $a
+        case -y --yes --force
+          set has_yes 1
+        case --no-yes --no-force
+          set has_no 1
+      end
+    end
+    set -l close_arg
+    if test $has_no -eq 1
+      set close_arg --no-yes
+    else if test $has_yes -eq 1
+      set close_arg -y
+    end
+
+    # Capture stderr (worktree path and -y flag) and stdout (main path).
+    # command substitution splits on newlines, so each stderr line becomes a
+    # list element: [1] = worktree path, [2] = -y flag (absent when not forced).
+    set -l stderr_output (command gw close --print-path $close_arg 2>&1 >/dev/null)
+    set -l main_path (command gw close --print-path $close_arg 2>/dev/null)
+
+    set -l worktree_to_remove $stderr_output[1]
+    set -l yes_flag ""
+    if test (count $stderr_output) -ge 2
+      set yes_flag $stderr_output[2]
+    end
+
     if test -n "$main_path" -a -n "$worktree_to_remove"
       if test "$yes_flag" = "-y"
         cd "$main_path"; and command gw rm -y "$worktree_to_remove"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -30,16 +32,20 @@ func init() {
 func runInit(cmd *cobra.Command, args []string) error {
 	shell := args[0]
 
+	var script string
 	switch shell {
 	case "bash", "zsh":
-		fmt.Print(bashZshInit)
+		script = bashZshInit
 	case "fish":
-		fmt.Print(fishInit)
+		script = fishInit
 	default:
 		return fmt.Errorf("unsupported shell: %s (supported: bash, zsh, fish)", shell)
 	}
 
-	return nil
+	// Use io.WriteString rather than fmt.Print so `go vet` doesn't flag the
+	// literal printf directives inside the shell script as format arguments.
+	_, err := io.WriteString(os.Stdout, script)
+	return err
 }
 
 const bashZshInit = `# gw shell integration
@@ -51,32 +57,25 @@ gw() {
       cd "$target"
     fi
   elif [ "$1" = "close" ] || [ "$1" = "c" ]; then
-    # Forward only the force flags that 'gw close' understands; other args
-    # (e.g. -b) are ignored so they don't trigger an unknown-flag error.
-    local has_yes="" has_no="" close_arg="" arg
-    for arg in "${@:2}"; do
-      case "$arg" in
-        -y|--yes|--force) has_yes=1 ;;
-        --no-yes|--no-force) has_no=1 ;;
-      esac
-    done
-    if [ -n "$has_no" ]; then close_arg="--no-yes"; elif [ -n "$has_yes" ]; then close_arg="-y"; fi
+    # 'gw close' understands the force (-y/-f) and branch (-b) flags, so forward
+    # every argument. It echoes the flags to pass on to 'gw rm' on separate
+    # stderr lines (line 2 = force, line 3 = branch).
+    local stderr_output main_path worktree_to_remove yes_flag branch_flag
+    stderr_output="$(command gw close --print-path "${@:2}" 2>&1 >/dev/null)"
+    main_path="$(command gw close --print-path "${@:2}" 2>/dev/null)"
 
-    # Capture stderr (worktree path and -y flag) and stdout (main path) separately
-    local stderr_output main_path worktree_to_remove yes_flag
-    stderr_output="$(command gw close --print-path $close_arg 2>&1 >/dev/null)"
-    main_path="$(command gw close --print-path $close_arg 2>/dev/null)"
-
-    # Parse stderr output: line 1 = worktree path, line 2 = -y flag
+    # Parse stderr: line 1 = worktree path, line 2 = force flag, line 3 = branch flag
     worktree_to_remove="$(sed -n '1p' <<< "$stderr_output")"
     yes_flag="$(sed -n '2p' <<< "$stderr_output")"
+    branch_flag="$(sed -n '3p' <<< "$stderr_output")"
 
     if [ -n "$main_path" ] && [ -n "$worktree_to_remove" ]; then
-      if [ "$yes_flag" = "-y" ]; then
-        cd "$main_path" && command gw rm -y "$worktree_to_remove"
-      else
-        cd "$main_path" && command gw rm "$worktree_to_remove"
-      fi
+      # Each flag holds a single token (or empty), so unquoted expansion yields
+      # one word (or none) in both bash and zsh.
+      cd "$main_path" && command gw rm $yes_flag $branch_flag "$worktree_to_remove"
+    elif [ -n "$stderr_output" ]; then
+      # 'gw close' failed (e.g. unknown or conflicting flag); surface its message.
+      printf '%s\n' "$stderr_output" >&2
     fi
   else
     command gw "$@"
@@ -92,43 +91,28 @@ function gw
       cd "$target"
     end
   else if test "$argv[1]" = "close" -o "$argv[1]" = "c"
-    # Forward only the force flags that 'gw close' understands; other args
-    # (e.g. -b) are ignored so they don't trigger an unknown-flag error.
-    set -l has_yes 0
-    set -l has_no 0
-    for a in $argv[2..]
-      switch $a
-        case -y --yes --force
-          set has_yes 1
-        case --no-yes --no-force
-          set has_no 1
-      end
-    end
-    set -l close_arg
-    if test $has_no -eq 1
-      set close_arg --no-yes
-    else if test $has_yes -eq 1
-      set close_arg -y
-    end
-
-    # Capture stderr (worktree path and -y flag) and stdout (main path).
-    # command substitution splits on newlines, so each stderr line becomes a
-    # list element: [1] = worktree path, [2] = -y flag (absent when not forced).
-    set -l stderr_output (command gw close --print-path $close_arg 2>&1 >/dev/null)
-    set -l main_path (command gw close --print-path $close_arg 2>/dev/null)
+    # 'gw close' understands the force (-y/-f) and branch (-b) flags, so forward
+    # every argument. It echoes the flags to pass on to 'gw rm' on separate
+    # stderr lines (line 2 = force, line 3 = branch).
+    # command substitution splits on newlines: [1] = worktree path, and the
+    # remaining elements are the flags for 'gw rm'.
+    set -l stderr_output (command gw close --print-path $argv[2..] 2>&1 >/dev/null)
+    set -l main_path (command gw close --print-path $argv[2..] 2>/dev/null)
 
     set -l worktree_to_remove $stderr_output[1]
-    set -l yes_flag ""
-    if test (count $stderr_output) -ge 2
-      set yes_flag $stderr_output[2]
+    # Collect the non-empty flag lines (order preserved: force then branch).
+    set -l rm_flags
+    for f in $stderr_output[2..-1]
+      if test -n "$f"
+        set -a rm_flags $f
+      end
     end
 
     if test -n "$main_path" -a -n "$worktree_to_remove"
-      if test "$yes_flag" = "-y"
-        cd "$main_path"; and command gw rm -y "$worktree_to_remove"
-      else
-        cd "$main_path"; and command gw rm "$worktree_to_remove"
-      end
+      cd "$main_path"; and command gw rm $rm_flags "$worktree_to_remove"
+    else if test -n "$stderr_output"
+      # 'gw close' failed (e.g. unknown or conflicting flag); surface its message.
+      printf '%s\n' $stderr_output >&2
     end
   else
     command gw $argv

--- a/cmd/init_shell_test.go
+++ b/cmd/init_shell_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests exercise the *behaviour* of the generated shell wrappers rather
+// than asserting on substrings of the generated script. A stub `gw` is placed
+// first on PATH so that `command gw ...` inside the wrapper resolves to it: the
+// stub emulates `gw close --print-path` output and records the arguments the
+// wrapper ultimately passes to `gw rm`. This is what actually guards issue #34
+// (the worktree path and the -y flag must reach `gw rm` as separate arguments).
+
+// stubGw is a bash script (run via its shebang regardless of the calling shell)
+// that emulates the two gw sub-commands the wrapper invokes.
+const stubGw = `#!/usr/bin/env bash
+case "$1" in
+  close)
+    echo "$GW_MAIN_PATH"
+    echo "$GW_WT_PATH" >&2
+    force=""
+    for a in "$@"; do
+      case "$a" in -y|--yes|--force) force="-y" ;; esac
+    done
+    if [ "$GW_STUB_FORCE" = "1" ] && [ -z "$force" ]; then force="-y"; fi
+    for a in "$@"; do
+      case "$a" in --no-yes|--no-force) force="" ;; esac
+    done
+    echo "$force" >&2
+    ;;
+  rm)
+    shift
+    : > "$GW_RM_ARGS_FILE"
+    for a in "$@"; do printf '%s\000' "$a" >> "$GW_RM_ARGS_FILE"; done
+    ;;
+esac
+`
+
+// runWrapperClose sources the given wrapper script in the given shell, runs
+// `gw <closeArgs>`, and returns the arguments the wrapper passed to `gw rm`.
+func runWrapperClose(t *testing.T, shell, wrapper, wrapperExt string, stubForce bool, closeArgs ...string) []string {
+	t.Helper()
+
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "gw"), []byte(stubGw), 0o755); err != nil {
+		t.Fatalf("write stub gw: %v", err)
+	}
+
+	mainPath := filepath.Join(dir, "main") // must exist: wrapper does `cd "$main"`
+	wtPath := filepath.Join(dir, "wt")     // recorded, not removed (rm is stubbed)
+	for _, p := range []string{mainPath, wtPath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	wrapperFile := filepath.Join(dir, "wrapper"+wrapperExt)
+	if err := os.WriteFile(wrapperFile, []byte(wrapper), 0o644); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	rmArgsFile := filepath.Join(dir, "rm_args")
+
+	script := "source '" + wrapperFile + "'; gw " + strings.Join(closeArgs, " ")
+	cmd := exec.Command(shell, "-c", script)
+	force := "0"
+	if stubForce {
+		force = "1"
+	}
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GW_MAIN_PATH="+mainPath,
+		"GW_WT_PATH="+wtPath,
+		"GW_RM_ARGS_FILE="+rmArgsFile,
+		"GW_STUB_FORCE="+force,
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("running wrapper in %s failed: %v\nstderr: %s", shell, err, stderr.String())
+	}
+
+	data, err := os.ReadFile(rmArgsFile)
+	if err != nil {
+		t.Fatalf("gw rm was never called (no args file): %v\nstderr: %s", err, stderr.String())
+	}
+	// Split on the NUL separator; drop the trailing empty element.
+	parts := strings.Split(string(data), "\x00")
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	// Normalise the recorded worktree path to the placeholder "WT" so callers
+	// can write expectations without knowing the temp dir.
+	for i, p := range parts {
+		if p == wtPath {
+			parts[i] = "WT"
+		}
+	}
+	return parts
+}
+
+func requireShell(t *testing.T, shell string) {
+	t.Helper()
+	if _, err := exec.LookPath(shell); err != nil {
+		t.Skipf("%s not available: %v", shell, err)
+	}
+}
+
+func equalArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCloseWrapperBehavior_PosixShells(t *testing.T) {
+	cases := []struct {
+		name      string
+		stubForce bool
+		closeArgs []string
+		wantRm    []string
+	}{
+		// #34 core: with force enabled the path and -y must reach gw rm as two
+		// separate args (the bug passed "<path>\n-y" as one arg).
+		{"config force separates path and -y", true, []string{"close"}, []string{"-y", "WT"}},
+		// Ancillary: `gw close -y` must forward the CLI flag, not only config.
+		{"cli -y is forwarded", false, []string{"close", "-y"}, []string{"-y", "WT"}},
+		// No force: gw rm is called without -y.
+		{"no force omits -y", false, []string{"close"}, []string{"WT"}},
+		// Non-close flags (e.g. -b) are dropped, so gw close does not error and
+		// the close still happens.
+		{"unknown flag -b is ignored", false, []string{"close", "-b"}, []string{"WT"}},
+	}
+
+	for _, shell := range []string{"bash", "zsh"} {
+		shell := shell
+		t.Run(shell, func(t *testing.T) {
+			requireShell(t, shell)
+			for _, tc := range cases {
+				tc := tc
+				t.Run(tc.name, func(t *testing.T) {
+					got := runWrapperClose(t, shell, bashZshInit, ".sh", tc.stubForce, tc.closeArgs...)
+					if !equalArgs(got, tc.wantRm) {
+						t.Errorf("gw rm args = %q, want %q", got, tc.wantRm)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestCloseWrapperBehavior_Fish(t *testing.T) {
+	requireShell(t, "fish")
+	cases := []struct {
+		name      string
+		stubForce bool
+		closeArgs []string
+		wantRm    []string
+	}{
+		{"config force separates path and -y", true, []string{"close"}, []string{"-y", "WT"}},
+		{"cli -y is forwarded", false, []string{"close", "-y"}, []string{"-y", "WT"}},
+		{"no force omits -y", false, []string{"close"}, []string{"WT"}},
+		{"unknown flag -b is ignored", false, []string{"close", "-b"}, []string{"WT"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := runWrapperClose(t, "fish", fishInit, ".fish", tc.stubForce, tc.closeArgs...)
+			if !equalArgs(got, tc.wantRm) {
+				t.Errorf("gw rm args = %q, want %q", got, tc.wantRm)
+			}
+		})
+	}
+}

--- a/cmd/init_shell_test.go
+++ b/cmd/init_shell_test.go
@@ -17,21 +17,28 @@ import (
 // (the worktree path and the -y flag must reach `gw rm` as separate arguments).
 
 // stubGw is a bash script (run via its shebang regardless of the calling shell)
-// that emulates the two gw sub-commands the wrapper invokes.
+// that emulates the two gw sub-commands the wrapper invokes. It mirrors the real
+// 'gw close --print-path' protocol: stdout = main path, stderr line 1 = worktree
+// path, line 2 = force flag (-y), line 3 = branch flag (-b).
 const stubGw = `#!/usr/bin/env bash
 case "$1" in
   close)
     echo "$GW_MAIN_PATH"
     echo "$GW_WT_PATH" >&2
     force=""
+    branch=""
     for a in "$@"; do
-      case "$a" in -y|--yes|--force) force="-y" ;; esac
+      case "$a" in
+        -y|-f|--yes|--force) force="-y" ;;
+        -b|--branch) branch="-b" ;;
+      esac
     done
     if [ "$GW_STUB_FORCE" = "1" ] && [ -z "$force" ]; then force="-y"; fi
     for a in "$@"; do
       case "$a" in --no-yes|--no-force) force="" ;; esac
     done
     echo "$force" >&2
+    echo "$branch" >&2
     ;;
   rm)
     shift
@@ -140,9 +147,10 @@ func TestCloseWrapperBehavior_PosixShells(t *testing.T) {
 		{"cli -y is forwarded", false, []string{"close", "-y"}, []string{"-y", "WT"}},
 		// No force: gw rm is called without -y.
 		{"no force omits -y", false, []string{"close"}, []string{"WT"}},
-		// Non-close flags (e.g. -b) are dropped, so gw close does not error and
-		// the close still happens.
-		{"unknown flag -b is ignored", false, []string{"close", "-b"}, []string{"WT"}},
+		// #36: -b is forwarded to gw rm so the branch is also deleted.
+		{"cli -b forwards branch deletion", false, []string{"close", "-b"}, []string{"-b", "WT"}},
+		// #36: -f -b forwards both force and branch (force-delete unmerged branch).
+		{"force and branch forwarded together", false, []string{"close", "-f", "-b"}, []string{"-y", "-b", "WT"}},
 	}
 
 	for _, shell := range []string{"bash", "zsh"} {
@@ -173,7 +181,8 @@ func TestCloseWrapperBehavior_Fish(t *testing.T) {
 		{"config force separates path and -y", true, []string{"close"}, []string{"-y", "WT"}},
 		{"cli -y is forwarded", false, []string{"close", "-y"}, []string{"-y", "WT"}},
 		{"no force omits -y", false, []string{"close"}, []string{"WT"}},
-		{"unknown flag -b is ignored", false, []string{"close", "-b"}, []string{"WT"}},
+		{"cli -b forwards branch deletion", false, []string{"close", "-b"}, []string{"-b", "WT"}},
+		{"force and branch forwarded together", false, []string{"close", "-f", "-b"}, []string{"-y", "-b", "WT"}},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -82,44 +82,43 @@ func containsSubstring(s, substr string) bool {
 	return false
 }
 
-// TestBashZshInit_ClosePathAndYesSeparation guards against regressions where the
-// bash/zsh wrapper captured the whole stderr (worktree path + "-y") into a single
-// variable and passed "<path>\n-y" as one argument to `gw rm` (issue #34).
-func TestBashZshInit_ClosePathAndYesSeparation(t *testing.T) {
+// TestBashZshInit_ClosePathAndFlagSeparation guards against regressions where the
+// bash/zsh wrapper captured the whole stderr (worktree path + rm flags) into a
+// single variable and passed "<path>\n<flags>" as one argument to `gw rm`
+// (issue #34), and ensures the flags line is forwarded to `gw rm` (issue #36).
+func TestBashZshInit_ClosePathAndFlagSeparation(t *testing.T) {
 	requiredElements := []string{
-		"sed -n '1p'",             // extract worktree path (line 1)
-		"sed -n '2p'",             // extract -y flag (line 2)
-		"command gw rm -y",        // forward -y when close.force is enabled
-		`for arg in "${@:2}"`,     // inspect CLI args (e.g. `gw close -y`)
-		"-y|--yes|--force",        // whitelist the force flags close understands
-		"--no-yes|--no-force",     // ...and their negations
-		"--print-path $close_arg", // forward only whitelisted flags to close
+		"sed -n '1p'",                          // extract worktree path (line 1)
+		"sed -n '2p'",                          // extract force flag (line 2)
+		"sed -n '3p'",                          // extract branch flag (line 3)
+		`command gw rm $yes_flag $branch_flag`, // forward the flags to gw rm
+		`--print-path "${@:2}"`,                // forward every user arg to gw close
+		`printf '%s\n' "$stderr_output" >&2`,   // surface close errors (issue #36 #1)
 	}
 
 	for _, elem := range requiredElements {
 		if !containsString(bashZshInit, elem) {
-			t.Errorf("bashZshInit should contain %q to separate the worktree path from the -y flag", elem)
+			t.Errorf("bashZshInit should contain %q to separate the worktree path from the rm flags", elem)
 		}
 	}
 }
 
-// TestFishInit_ClosePathAndYesSeparation guards against the fish wrapper joining
+// TestFishInit_ClosePathAndFlagSeparation guards against the fish wrapper joining
 // the stderr list with spaces (echo "$list" | sed) instead of reading the path and
-// -y flag as separate list elements (issue #34).
-func TestFishInit_ClosePathAndYesSeparation(t *testing.T) {
+// flags as separate list elements (issue #34), and ensures the flags line is
+// forwarded to `gw rm` (issue #36).
+func TestFishInit_ClosePathAndFlagSeparation(t *testing.T) {
 	requiredElements := []string{
-		"$stderr_output[1]",        // worktree path
-		"$stderr_output[2]",        // -y flag
-		"command gw rm -y",         // forward -y when close.force is enabled
-		"for a in $argv[2..]",      // inspect CLI args
-		"case -y --yes --force",    // whitelist the force flags close understands
-		"case --no-yes --no-force", // ...and their negations
-		"--print-path $close_arg",  // forward only whitelisted flags to close
+		"$stderr_output[1]",             // worktree path
+		"$stderr_output[2..-1]",         // remaining lines = rm flags
+		"command gw rm $rm_flags",       // forward the flags to gw rm
+		"--print-path $argv[2..]",       // forward every user arg to gw close
+		"printf '%s\\n' $stderr_output", // surface close errors (issue #36 #1)
 	}
 
 	for _, elem := range requiredElements {
 		if !containsString(fishInit, elem) {
-			t.Errorf("fishInit should contain %q to read the worktree path and -y flag separately", elem)
+			t.Errorf("fishInit should contain %q to read the worktree path and rm flags separately", elem)
 		}
 	}
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -82,6 +82,48 @@ func containsSubstring(s, substr string) bool {
 	return false
 }
 
+// TestBashZshInit_ClosePathAndYesSeparation guards against regressions where the
+// bash/zsh wrapper captured the whole stderr (worktree path + "-y") into a single
+// variable and passed "<path>\n-y" as one argument to `gw rm` (issue #34).
+func TestBashZshInit_ClosePathAndYesSeparation(t *testing.T) {
+	requiredElements := []string{
+		"sed -n '1p'",             // extract worktree path (line 1)
+		"sed -n '2p'",             // extract -y flag (line 2)
+		"command gw rm -y",        // forward -y when close.force is enabled
+		`for arg in "${@:2}"`,     // inspect CLI args (e.g. `gw close -y`)
+		"-y|--yes|--force",        // whitelist the force flags close understands
+		"--no-yes|--no-force",     // ...and their negations
+		"--print-path $close_arg", // forward only whitelisted flags to close
+	}
+
+	for _, elem := range requiredElements {
+		if !containsString(bashZshInit, elem) {
+			t.Errorf("bashZshInit should contain %q to separate the worktree path from the -y flag", elem)
+		}
+	}
+}
+
+// TestFishInit_ClosePathAndYesSeparation guards against the fish wrapper joining
+// the stderr list with spaces (echo "$list" | sed) instead of reading the path and
+// -y flag as separate list elements (issue #34).
+func TestFishInit_ClosePathAndYesSeparation(t *testing.T) {
+	requiredElements := []string{
+		"$stderr_output[1]",        // worktree path
+		"$stderr_output[2]",        // -y flag
+		"command gw rm -y",         // forward -y when close.force is enabled
+		"for a in $argv[2..]",      // inspect CLI args
+		"case -y --yes --force",    // whitelist the force flags close understands
+		"case --no-yes --no-force", // ...and their negations
+		"--print-path $close_arg",  // forward only whitelisted flags to close
+	}
+
+	for _, elem := range requiredElements {
+		if !containsString(fishInit, elem) {
+			t.Errorf("fishInit should contain %q to read the worktree path and -y flag separately", elem)
+		}
+	}
+}
+
 func TestRunInit_UnsupportedShell(t *testing.T) {
 	err := runInit(initCmd, []string{"powershell"})
 	if err == nil {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -64,10 +64,10 @@ Examples:
 
 func init() {
 	rmCmd.Flags().BoolVarP(&rmConfig.Force, "force", "f", false, "Force removal even if worktree is dirty")
-	rmCmd.Flags().BoolVarP(&rmConfig.Yes, "yes", "y", false, "Skip confirmation prompt (alias for --force)")
+	rmCmd.Flags().BoolVarP(&rmConfig.Yes, "yes", "y", false, "Force removal even if worktree is dirty (alias for --force)")
 	rmCmd.Flags().BoolVarP(&rmConfig.Branch, "branch", "b", false, "Also delete the associated git branch")
 	// Negation flags
-	rmCmd.Flags().BoolVar(&rmConfig.NoYes, "no-yes", false, "Force disable automatic confirmation (overrides config and --yes)")
+	rmCmd.Flags().BoolVar(&rmConfig.NoYes, "no-yes", false, "Disable force removal (overrides config and --yes)")
 	rmCmd.Flags().BoolVar(&rmConfig.NoForce, "no-force", false, "Alias for --no-yes")
 	rmCmd.Flags().BoolVar(&rmConfig.NoBranch, "no-branch", false, "Force disable branch deletion (overrides config and --branch)")
 	rootCmd.AddCommand(rmCmd)

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -31,15 +31,17 @@ add:
 
 # Close command configuration
 close:
-  # Automatically confirm worktree deletion without prompting
-  # When true, 'gw close' will pass -y flag to 'gw rm' automatically
+  # Force worktree removal even when the worktree is dirty or locked
+  # When true, 'gw close' passes -y (force) to 'gw rm' automatically
+  # Note: there is no interactive confirmation prompt; this is a force flag
   # Default: false
   force: true
 
 # Rm command configuration
 rm:
-  # Automatically confirm worktree deletion without prompting
-  # When true, skips confirmation prompt when removing worktrees
+  # Force removal of dirty/locked worktrees (and unmerged branches with -b)
+  # When true, passes --force to 'git worktree remove' (and 'git branch -D')
+  # Note: there is no interactive confirmation prompt; this is a force flag
   # Default: false
   force: true
 
@@ -65,5 +67,5 @@ editor: code
 # --no-* flags have the highest priority and will force the value to false:
 #   gw add --open --no-open feature/test  # Error: cannot use both flags together
 #   gw add --no-open feature/test          # Will NOT open even if config.add.open is true
-#   gw close --no-yes                      # Will NOT auto-confirm even if config.close.force is true
+#   gw close --no-yes                      # Will NOT force removal even if config.close.force is true
 #   gw rm --no-branch feature/test         # Will NOT delete branch even if config.rm.branch is true


### PR DESCRIPTION
## 概要
3件の issue に対応します。

- **#34**: bash/zsh の `gw close` が `close.force=true` で `worktree not found` により失敗する
- **#36**: README に載っている `gw close -b` / `--branch` / `-f -b` が未実装で、実行すると unknown-shorthand エラーになる
- **#38**: `-y`/`--yes`/`force` を「確認プロンプトをスキップ」と説明しているが、実際にはプロンプトは存在しない

## #34: close wrapper の行分離バグ (fix)
### 原因
`gw close --print-path` は stderr に削除対象 worktree パス等を出力しますが、bash/zsh ラッパーは stderr を丸ごと1変数に取り込み、`worktree_to_remove="<path>\n<flags>"` を **単一引数**として `gw rm` に渡すため `FindWorktree` が解決できず失敗していました。

fish ラッパーは行分離しているように見えますが、`echo "$stderr_output" | sed` が **リストをスペース結合**するため（`set (cmd)` の改行分割 → `"$list"` 展開でスペース結合）、`force=true` 時に同様に壊れていました（issue の「fish は正常」は誤り、検証で判明）。

### 修正
- `gw close --print-path` の stderr 出力を **1フラグ=1行・単一トークン**に整理: 1行目=削除対象 worktree パス、2行目=force フラグ（`-y` or 空）、3行目=branch フラグ（`-b` or 空）
- bash/zsh: `sed -n '1p'/'2p'/'3p'` で各行を個別変数に取り出し、`command gw rm $yes_flag $branch_flag "$worktree_to_remove"` として渡す。各変数は「1トークン or 空」なので、**zsh が未クォート変数を単語分割しない**環境でも1語（または0語）に収まり、#34 の複数トークン混入を根本から回避
- fish: `echo | sed` をやめ、リスト要素 `$stderr_output[1]`（パス）と `$stderr_output[2..-1]`（フラグ群）を直接参照
- 付随対応: `gw close -y` の CLI フラグが `--print-path` に転送されず config 経由でしか効かなかった問題も修正

## #36: `gw close -b` / `--branch` / `-f -b` の実装 (fix)
README のコマンド一覧・使用例には `gw close -b`（worktree とブランチを削除）や `gw close -f -b`（未マージブランチを強制削除）が記載されていましたが、`cmd/close.go` にこれらのフラグが未定義で、実行すると cobra が unknown-shorthand エラーで弾いていました（`git show main:cmd/close.go` で確認）。

- `cmd/close.go` に `-b/--branch`（および `--force` の `-f` shorthand）を正式なフラグとして追加
- ラッパーはユーザー引数（`"${@:2}"` / `$argv[2..]`）を **すべて `gw close` に渡し**、cobra がパースします（機構上「ホワイトリスト」は存在しません）。`close.go` が `-y/-f/-b/--no-yes/--no-force` と config を解決し、`gw rm` へ渡すべき `-y`/`-b` トークンを算出して前述の stderr プロトコルで出力、ラッパーがそれを `gw rm` に転送します
- 未知/矛盾フラグは cobra がエラーにし、ラッパーの分岐でそのメッセージを **stderr に surface**（従来は握り潰し）
- ブランチ削除の安全性は既存の `gw rm` に委譲（`main`/`master`/カレントブランチは拒否、force なしでは未マージブランチを拒否）

## #38: force フラグのドキュメント整合 (docs)
確認プロンプトは実装に存在せず、`-y`/`force` の実体は force フラグ（`git worktree remove --force` / `git branch -D`）です。README・`examples/config.yaml`・`cmd/rm.go`/`cmd/close.go` のフラグ help を実態（force 動作）に合わせて修正しました。

> #38 には「実際にプロンプトを実装する」という別案もありますが、シェル統合が `close` 時に自動で `-y` を渡す非対話フローと矛盾するため、ラベル(`documentation`)通りドキュメント整合を採りました。実プロンプト実装をご希望なら方針変更します。

## 検証
実バイナリ + 生成ラッパー + スタブ `gw` による**振る舞いベースの回帰テスト**（`cmd/init_shell_test.go`）を bash/zsh/fish で追加。`gw rm` に届く引数を検証します。

| ケース | bash/zsh | fish |
|---|---|---|
| config force（dirty worktree） | ✅ `-y WT` | ✅ `-y WT` |
| CLI `-y` | ✅ `-y WT` | ✅ `-y WT` |
| force なし | ✅ `WT` | ✅ `WT` |
| `close -b`（#36 ブランチ削除） | ✅ `-b WT` | ✅ `-b WT` |
| `close -f -b`（#36 force+branch） | ✅ `-y -b WT` | ✅ `-y -b WT` |

さらに実 git repo（`XDG_CONFIG_HOME` を一時ディレクトリに隔離）に対する end-to-end で、`-b`/`--branch`/`-f -b` が実際にブランチを削除し、未マージ・force なしでは削除を拒否することを確認。

- `go test ./...`（`-race` 含む）全 PASS、`go vet` クリーン、変更ファイルは golangci-lint クリーン

> [!NOTE]
> `cmd/add_helpers.go` の errcheck 2件は本 PR の変更対象外の既存 lint 指摘です（未修正）。
