### PR TITLE
docs: remove unsupported name: field from hook examples in add/rm help

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -51,11 +51,9 @@ Hooks:
   Example gw.yaml:
     hooks:
       pre_add:
-        - name: "Validate branch name"
-          command: echo "Creating worktree for $GW_BRANCH"
+        - command: echo "Creating worktree for $GW_BRANCH"
       post_add:
-        - name: "Install dependencies"
-          command: npm install
+        - command: npm install
 
 Examples:
   gw add feature/hoge

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -48,13 +48,11 @@ Hooks:
   Example gw.yaml:
     hooks:
       pre_remove:
-        - name: "Backup data"
-          command: |
+        - command: |
             echo "Backing up data from $GW_WORKTREE_PATH"
             tar -czf "$GW_REPO_ROOT/backup-$GW_BRANCH.tar.gz" .
       post_remove:
-        - name: "Clean up artifacts"
-          command: echo "Cleaned up worktree for $GW_BRANCH"
+        - command: echo "Cleaned up worktree for $GW_BRANCH"
 
 Examples:
   gw rm feature/hoge


### PR DESCRIPTION
## 概要
`gw add` / `gw rm` の `--help`（Long 説明）のフック例が、実装が対応していない `name:` フィールドを使っていた不整合を修正します。

## 変更
- `cmd/add.go` / `cmd/rm.go` の `Example gw.yaml` から `name:` 行を削除
- 実装（`Hook` 構造体は `command` / `env` のみ）・README・`examples/gw.yaml` と整合

## 方針
issue #39 の「要判断」について、`Hook` に `name` を実装する案ではなく、ヘルプから `name:` を削除する最小のドキュメント修正を選択（README/examples が既に `name:` 無しで正しいため）。

## 確認
- `go build` / `go vet` / `go fmt` 通過（Docker）
- `gw add --help` / `gw rm --help` の出力が `name:` 無しになることを確認

Closes #39