### PR TITLE
feat: close コマンドに -b/--branch と -f を実装 (#36)

### DIFF
--- a/cmd/close.go
+++ b/cmd/close.go
@@ -16,6 +16,7 @@ var closeConfig = struct {
 	PrintPath bool
 	Yes       bool
 	Force     bool
+	Branch    bool
 	NoYes     bool
 	NoForce   bool
 }{}
@@ -33,7 +34,9 @@ This command must be run from within a non-main worktree. It will:
 Note: This command requires shell integration. Run 'gw init <shell>' to set up.
 
 Examples:
-  gw close       # Close current worktree and switch to main`,
+  gw close          # Close current worktree and switch to main
+  gw close -b       # Also delete the associated branch
+  gw close -f -b    # Force close and delete an unmerged branch`,
 	Args: cobra.NoArgs,
 	RunE: runClose,
 }
@@ -41,7 +44,8 @@ Examples:
 func init() {
 	closeCmd.Flags().BoolVar(&closeConfig.PrintPath, "print-path", false, "Print the path instead of changing directory (used by shell wrapper)")
 	closeCmd.Flags().BoolVarP(&closeConfig.Yes, "yes", "y", false, "Force worktree removal even if dirty (forwarded to gw rm by the shell wrapper)")
-	closeCmd.Flags().BoolVar(&closeConfig.Force, "force", false, "Alias for --yes")
+	closeCmd.Flags().BoolVarP(&closeConfig.Force, "force", "f", false, "Alias for --yes")
+	closeCmd.Flags().BoolVarP(&closeConfig.Branch, "branch", "b", false, "Also delete the associated git branch (forwarded to gw rm by the shell wrapper)")
 	closeCmd.Flags().BoolVar(&closeConfig.NoYes, "no-yes", false, "Disable force removal (overrides config and --yes)")
 	closeCmd.Flags().BoolVar(&closeConfig.NoForce, "no-force", false, "Alias for --no-yes")
 	rootCmd.AddCommand(closeCmd)
@@ -109,24 +113,47 @@ func runClose(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get main worktree path: %w", err)
 	}
 
+	// Determine the flags to forward to 'gw rm' via the shell wrapper.
+	// Force (-y) forces removal of a dirty worktree and deletion of an
+	// unmerged branch; branch (-b) also deletes the associated git branch.
+	yesFlag := ""
+	if mergedConfig.Close.Force {
+		yesFlag = "-y"
+	}
+	branchFlag := ""
+	if closeConfig.Branch {
+		branchFlag = "-b"
+	}
+
 	if closeConfig.PrintPath {
 		// Print the main worktree path for shell wrapper to use (stdout)
 		fmt.Println(mainPath)
 		// Print the current worktree path on stderr for the shell wrapper to remove
 		fmt.Fprintf(os.Stderr, "%s\n", currentWT.Path)
-		// Print -y flag status on stderr (second line)
-		if mergedConfig.Close.Force {
-			fmt.Fprintf(os.Stderr, "-y\n")
-		} else {
-			fmt.Fprintf(os.Stderr, "\n")
-		}
+		// Print the flags to forward to 'gw rm' on their own stderr lines
+		// (line 2 = force, line 3 = branch). Keeping each flag on a separate
+		// line lets the wrapper forward them without word-splitting a joined
+		// string, which zsh does not do by default.
+		fmt.Fprintf(os.Stderr, "%s\n", yesFlag)
+		fmt.Fprintf(os.Stderr, "%s\n", branchFlag)
 		return nil
 	}
 
 	// Without shell integration, we can't actually change directory
 	// Print instructions
+	var rmFlags []string
+	if yesFlag != "" {
+		rmFlags = append(rmFlags, yesFlag)
+	}
+	if branchFlag != "" {
+		rmFlags = append(rmFlags, branchFlag)
+	}
+	rmInvocation := "gw rm"
+	if len(rmFlags) > 0 {
+		rmInvocation += " " + strings.Join(rmFlags, " ")
+	}
 	fmt.Fprintf(os.Stderr, "To close this worktree and switch to main, run:\n")
-	fmt.Fprintf(os.Stderr, "  cd %s && gw rm %s\n\n", mainPath, currentWT.Path)
+	fmt.Fprintf(os.Stderr, "  cd %s && %s %s\n\n", mainPath, rmInvocation, currentWT.Path)
 	fmt.Fprintf(os.Stderr, "For automatic directory switching and worktree removal, set up shell integration:\n")
 	fmt.Fprintf(os.Stderr, "  eval \"$(gw init bash)\"   # for bash\n")
 	fmt.Fprintf(os.Stderr, "  eval \"$(gw init zsh)\"    # for zsh\n")

--- a/cmd/close_test.go
+++ b/cmd/close_test.go
@@ -63,6 +63,33 @@ func TestCloseCmd_ForceFlag(t *testing.T) {
 	}
 }
 
+func TestCloseCmd_ForceFlagShorthand(t *testing.T) {
+	flag := closeCmd.Flags().Lookup("force")
+	if flag == nil {
+		t.Fatal("Expected 'force' flag to be defined")
+	}
+	if flag.Shorthand != "f" {
+		t.Errorf("Expected shorthand 'f', got '%s'", flag.Shorthand)
+	}
+}
+
+func TestCloseCmd_BranchFlag(t *testing.T) {
+	flag := closeCmd.Flags().Lookup("branch")
+	if flag == nil {
+		t.Fatal("Expected 'branch' flag to be defined")
+	}
+}
+
+func TestCloseCmd_BranchFlagShorthand(t *testing.T) {
+	flag := closeCmd.Flags().Lookup("branch")
+	if flag == nil {
+		t.Fatal("Expected 'branch' flag to be defined")
+	}
+	if flag.Shorthand != "b" {
+		t.Errorf("Expected shorthand 'b', got '%s'", flag.Shorthand)
+	}
+}
+
 func TestCloseCmd_NoYesFlag(t *testing.T) {
 	flag := closeCmd.Flags().Lookup("no-yes")
 	if flag == nil {

--- a/cmd/close_test.go
+++ b/cmd/close_test.go
@@ -1,6 +1,11 @@
 package cmd
 
 import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/t98o84/gw/internal/git"
@@ -168,4 +173,157 @@ func TestFindCurrentWorktree(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunClose_PrintPathProtocol drives runClose against a real git worktree and
+// verifies the --print-path protocol the shell wrapper relies on: stdout carries
+// the main worktree path, and stderr carries the worktree path (line 1), the
+// force flag (line 2) and the branch flag (line 3). This exercises the core
+// flag-forwarding behaviour of issue #36 end to end.
+func TestRunClose_PrintPathProtocol(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Isolate config so a user's ~/.config/gw/config.yaml can't flip close.force.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// EvalSymlinks so paths match what git reports (e.g. /var -> /private/var on macOS).
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repo, "init", "-q", "-b", "main")
+	gitCmd(t, repo, "commit", "-q", "--allow-empty", "-m", "init")
+	wt := filepath.Join(root, "wt")
+	gitCmd(t, repo, "worktree", "add", "-q", wt, "-b", "feature")
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWd)
+		resetCloseFlags(t)
+	})
+	if err := os.Chdir(wt); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		yes        bool
+		branch     bool
+		wantForce  string
+		wantBranch string
+	}{
+		{"no flags", false, false, "", ""},
+		{"force only", true, false, "-y", ""},
+		{"branch only", false, true, "", "-b"},
+		{"force and branch", true, true, "-y", "-b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetCloseFlags(t)
+			mustSetFlag(t, "print-path", "true")
+			if tt.yes {
+				mustSetFlag(t, "yes", "true")
+			}
+			if tt.branch {
+				mustSetFlag(t, "branch", "true")
+			}
+
+			stdout, stderr := captureStdoutStderr(t, func() {
+				if err := runClose(closeCmd, nil); err != nil {
+					t.Fatalf("runClose returned error: %v", err)
+				}
+			})
+
+			if gotMain := strings.TrimSpace(stdout); gotMain != repo {
+				t.Errorf("stdout main path = %q, want %q", gotMain, repo)
+			}
+
+			lines := strings.Split(strings.TrimRight(stderr, "\n"), "\n")
+			if lineAt(lines, 0) != wt {
+				t.Errorf("stderr line 1 (worktree path) = %q, want %q", lineAt(lines, 0), wt)
+			}
+			if got := lineAt(lines, 1); got != tt.wantForce {
+				t.Errorf("stderr line 2 (force flag) = %q, want %q", got, tt.wantForce)
+			}
+			if got := lineAt(lines, 2); got != tt.wantBranch {
+				t.Errorf("stderr line 3 (branch flag) = %q, want %q", got, tt.wantBranch)
+			}
+		})
+	}
+}
+
+// lineAt returns lines[i] or "" when the index is out of range (trailing empty
+// protocol lines are dropped by TrimRight).
+func lineAt(lines []string, i int) string {
+	if i < len(lines) {
+		return lines[i]
+	}
+	return ""
+}
+
+func mustSetFlag(t *testing.T, name, value string) {
+	t.Helper()
+	if err := closeCmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("set flag %s=%s: %v", name, value, err)
+	}
+}
+
+func resetCloseFlags(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"print-path", "yes", "force", "branch", "no-yes", "no-force"} {
+		if err := closeCmd.Flags().Set(name, "false"); err != nil {
+			t.Fatalf("reset flag %s: %v", name, err)
+		}
+	}
+}
+
+func gitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+// captureStdoutStderr swaps os.Stdout/os.Stderr for pipes while fn runs and
+// returns what was written. Output is expected to be small (well under the pipe
+// buffer), so reading after fn returns cannot deadlock.
+func captureStdoutStderr(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout, os.Stderr = outW, errW
+	defer func() { os.Stdout, os.Stderr = origOut, origErr }()
+
+	fn()
+
+	_ = outW.Close()
+	_ = errW.Close()
+	outBytes, _ := io.ReadAll(outR)
+	errBytes, _ := io.ReadAll(errR)
+	return string(outBytes), string(errBytes)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -30,16 +32,20 @@ func init() {
 func runInit(cmd *cobra.Command, args []string) error {
 	shell := args[0]
 
+	var script string
 	switch shell {
 	case "bash", "zsh":
-		fmt.Print(bashZshInit)
+		script = bashZshInit
 	case "fish":
-		fmt.Print(fishInit)
+		script = fishInit
 	default:
 		return fmt.Errorf("unsupported shell: %s (supported: bash, zsh, fish)", shell)
 	}
 
-	return nil
+	// Use io.WriteString rather than fmt.Print so `go vet` doesn't flag the
+	// literal printf directives inside the shell script as format arguments.
+	_, err := io.WriteString(os.Stdout, script)
+	return err
 }
 
 const bashZshInit = `# gw shell integration
@@ -67,6 +73,9 @@ gw() {
       # Each flag holds a single token (or empty), so unquoted expansion yields
       # one word (or none) in both bash and zsh.
       cd "$main_path" && command gw rm $yes_flag $branch_flag "$worktree_to_remove"
+    elif [ -n "$stderr_output" ]; then
+      # 'gw close' failed (e.g. unknown or conflicting flag); surface its message.
+      printf '%s\n' "$stderr_output" >&2
     fi
   else
     command gw "$@"
@@ -101,6 +110,9 @@ function gw
 
     if test -n "$main_path" -a -n "$worktree_to_remove"
       cd "$main_path"; and command gw rm $rm_flags "$worktree_to_remove"
+    else if test -n "$stderr_output"
+      # 'gw close' failed (e.g. unknown or conflicting flag); surface its message.
+      printf '%s\n' $stderr_output >&2
     end
   else
     command gw $argv

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -51,32 +51,22 @@ gw() {
       cd "$target"
     fi
   elif [ "$1" = "close" ] || [ "$1" = "c" ]; then
-    # Forward only the force flags that 'gw close' understands; other args
-    # (e.g. -b) are ignored so they don't trigger an unknown-flag error.
-    local has_yes="" has_no="" close_arg="" arg
-    for arg in "${@:2}"; do
-      case "$arg" in
-        -y|--yes|--force) has_yes=1 ;;
-        --no-yes|--no-force) has_no=1 ;;
-      esac
-    done
-    if [ -n "$has_no" ]; then close_arg="--no-yes"; elif [ -n "$has_yes" ]; then close_arg="-y"; fi
+    # 'gw close' understands the force (-y/-f) and branch (-b) flags, so forward
+    # every argument. It echoes the flags to pass on to 'gw rm' on separate
+    # stderr lines (line 2 = force, line 3 = branch).
+    local stderr_output main_path worktree_to_remove yes_flag branch_flag
+    stderr_output="$(command gw close --print-path "${@:2}" 2>&1 >/dev/null)"
+    main_path="$(command gw close --print-path "${@:2}" 2>/dev/null)"
 
-    # Capture stderr (worktree path and -y flag) and stdout (main path) separately
-    local stderr_output main_path worktree_to_remove yes_flag
-    stderr_output="$(command gw close --print-path $close_arg 2>&1 >/dev/null)"
-    main_path="$(command gw close --print-path $close_arg 2>/dev/null)"
-
-    # Parse stderr output: line 1 = worktree path, line 2 = -y flag
+    # Parse stderr: line 1 = worktree path, line 2 = force flag, line 3 = branch flag
     worktree_to_remove="$(sed -n '1p' <<< "$stderr_output")"
     yes_flag="$(sed -n '2p' <<< "$stderr_output")"
+    branch_flag="$(sed -n '3p' <<< "$stderr_output")"
 
     if [ -n "$main_path" ] && [ -n "$worktree_to_remove" ]; then
-      if [ "$yes_flag" = "-y" ]; then
-        cd "$main_path" && command gw rm -y "$worktree_to_remove"
-      else
-        cd "$main_path" && command gw rm "$worktree_to_remove"
-      fi
+      # Each flag holds a single token (or empty), so unquoted expansion yields
+      # one word (or none) in both bash and zsh.
+      cd "$main_path" && command gw rm $yes_flag $branch_flag "$worktree_to_remove"
     fi
   else
     command gw "$@"
@@ -92,43 +82,25 @@ function gw
       cd "$target"
     end
   else if test "$argv[1]" = "close" -o "$argv[1]" = "c"
-    # Forward only the force flags that 'gw close' understands; other args
-    # (e.g. -b) are ignored so they don't trigger an unknown-flag error.
-    set -l has_yes 0
-    set -l has_no 0
-    for a in $argv[2..]
-      switch $a
-        case -y --yes --force
-          set has_yes 1
-        case --no-yes --no-force
-          set has_no 1
-      end
-    end
-    set -l close_arg
-    if test $has_no -eq 1
-      set close_arg --no-yes
-    else if test $has_yes -eq 1
-      set close_arg -y
-    end
-
-    # Capture stderr (worktree path and -y flag) and stdout (main path).
-    # command substitution splits on newlines, so each stderr line becomes a
-    # list element: [1] = worktree path, [2] = -y flag (absent when not forced).
-    set -l stderr_output (command gw close --print-path $close_arg 2>&1 >/dev/null)
-    set -l main_path (command gw close --print-path $close_arg 2>/dev/null)
+    # 'gw close' understands the force (-y/-f) and branch (-b) flags, so forward
+    # every argument. It echoes the flags to pass on to 'gw rm' on separate
+    # stderr lines (line 2 = force, line 3 = branch).
+    # command substitution splits on newlines: [1] = worktree path, and the
+    # remaining elements are the flags for 'gw rm'.
+    set -l stderr_output (command gw close --print-path $argv[2..] 2>&1 >/dev/null)
+    set -l main_path (command gw close --print-path $argv[2..] 2>/dev/null)
 
     set -l worktree_to_remove $stderr_output[1]
-    set -l yes_flag ""
-    if test (count $stderr_output) -ge 2
-      set yes_flag $stderr_output[2]
+    # Collect the non-empty flag lines (order preserved: force then branch).
+    set -l rm_flags
+    for f in $stderr_output[2..-1]
+      if test -n "$f"
+        set -a rm_flags $f
+      end
     end
 
     if test -n "$main_path" -a -n "$worktree_to_remove"
-      if test "$yes_flag" = "-y"
-        cd "$main_path"; and command gw rm -y "$worktree_to_remove"
-      else
-        cd "$main_path"; and command gw rm "$worktree_to_remove"
-      end
+      cd "$main_path"; and command gw rm $rm_flags "$worktree_to_remove"
     end
   else
     command gw $argv

--- a/cmd/init_shell_test.go
+++ b/cmd/init_shell_test.go
@@ -17,21 +17,28 @@ import (
 // (the worktree path and the -y flag must reach `gw rm` as separate arguments).
 
 // stubGw is a bash script (run via its shebang regardless of the calling shell)
-// that emulates the two gw sub-commands the wrapper invokes.
+// that emulates the two gw sub-commands the wrapper invokes. It mirrors the real
+// 'gw close --print-path' protocol: stdout = main path, stderr line 1 = worktree
+// path, line 2 = force flag (-y), line 3 = branch flag (-b).
 const stubGw = `#!/usr/bin/env bash
 case "$1" in
   close)
     echo "$GW_MAIN_PATH"
     echo "$GW_WT_PATH" >&2
     force=""
+    branch=""
     for a in "$@"; do
-      case "$a" in -y|--yes|--force) force="-y" ;; esac
+      case "$a" in
+        -y|-f|--yes|--force) force="-y" ;;
+        -b|--branch) branch="-b" ;;
+      esac
     done
     if [ "$GW_STUB_FORCE" = "1" ] && [ -z "$force" ]; then force="-y"; fi
     for a in "$@"; do
       case "$a" in --no-yes|--no-force) force="" ;; esac
     done
     echo "$force" >&2
+    echo "$branch" >&2
     ;;
   rm)
     shift
@@ -140,9 +147,10 @@ func TestCloseWrapperBehavior_PosixShells(t *testing.T) {
 		{"cli -y is forwarded", false, []string{"close", "-y"}, []string{"-y", "WT"}},
 		// No force: gw rm is called without -y.
 		{"no force omits -y", false, []string{"close"}, []string{"WT"}},
-		// Non-close flags (e.g. -b) are dropped, so gw close does not error and
-		// the close still happens.
-		{"unknown flag -b is ignored", false, []string{"close", "-b"}, []string{"WT"}},
+		// #36: -b is forwarded to gw rm so the branch is also deleted.
+		{"cli -b forwards branch deletion", false, []string{"close", "-b"}, []string{"-b", "WT"}},
+		// #36: -f -b forwards both force and branch (force-delete unmerged branch).
+		{"force and branch forwarded together", false, []string{"close", "-f", "-b"}, []string{"-y", "-b", "WT"}},
 	}
 
 	for _, shell := range []string{"bash", "zsh"} {
@@ -173,7 +181,8 @@ func TestCloseWrapperBehavior_Fish(t *testing.T) {
 		{"config force separates path and -y", true, []string{"close"}, []string{"-y", "WT"}},
 		{"cli -y is forwarded", false, []string{"close", "-y"}, []string{"-y", "WT"}},
 		{"no force omits -y", false, []string{"close"}, []string{"WT"}},
-		{"unknown flag -b is ignored", false, []string{"close", "-b"}, []string{"WT"}},
+		{"cli -b forwards branch deletion", false, []string{"close", "-b"}, []string{"-b", "WT"}},
+		{"force and branch forwarded together", false, []string{"close", "-f", "-b"}, []string{"-y", "-b", "WT"}},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -82,44 +82,41 @@ func containsSubstring(s, substr string) bool {
 	return false
 }
 
-// TestBashZshInit_ClosePathAndYesSeparation guards against regressions where the
-// bash/zsh wrapper captured the whole stderr (worktree path + "-y") into a single
-// variable and passed "<path>\n-y" as one argument to `gw rm` (issue #34).
-func TestBashZshInit_ClosePathAndYesSeparation(t *testing.T) {
+// TestBashZshInit_ClosePathAndFlagSeparation guards against regressions where the
+// bash/zsh wrapper captured the whole stderr (worktree path + rm flags) into a
+// single variable and passed "<path>\n<flags>" as one argument to `gw rm`
+// (issue #34), and ensures the flags line is forwarded to `gw rm` (issue #36).
+func TestBashZshInit_ClosePathAndFlagSeparation(t *testing.T) {
 	requiredElements := []string{
-		"sed -n '1p'",             // extract worktree path (line 1)
-		"sed -n '2p'",             // extract -y flag (line 2)
-		"command gw rm -y",        // forward -y when close.force is enabled
-		`for arg in "${@:2}"`,     // inspect CLI args (e.g. `gw close -y`)
-		"-y|--yes|--force",        // whitelist the force flags close understands
-		"--no-yes|--no-force",     // ...and their negations
-		"--print-path $close_arg", // forward only whitelisted flags to close
+		"sed -n '1p'",                          // extract worktree path (line 1)
+		"sed -n '2p'",                          // extract force flag (line 2)
+		"sed -n '3p'",                          // extract branch flag (line 3)
+		`command gw rm $yes_flag $branch_flag`, // forward the flags to gw rm
+		`--print-path "${@:2}"`,                // forward every user arg to gw close
 	}
 
 	for _, elem := range requiredElements {
 		if !containsString(bashZshInit, elem) {
-			t.Errorf("bashZshInit should contain %q to separate the worktree path from the -y flag", elem)
+			t.Errorf("bashZshInit should contain %q to separate the worktree path from the rm flags", elem)
 		}
 	}
 }
 
-// TestFishInit_ClosePathAndYesSeparation guards against the fish wrapper joining
+// TestFishInit_ClosePathAndFlagSeparation guards against the fish wrapper joining
 // the stderr list with spaces (echo "$list" | sed) instead of reading the path and
-// -y flag as separate list elements (issue #34).
-func TestFishInit_ClosePathAndYesSeparation(t *testing.T) {
+// flags as separate list elements (issue #34), and ensures the flags line is
+// forwarded to `gw rm` (issue #36).
+func TestFishInit_ClosePathAndFlagSeparation(t *testing.T) {
 	requiredElements := []string{
-		"$stderr_output[1]",        // worktree path
-		"$stderr_output[2]",        // -y flag
-		"command gw rm -y",         // forward -y when close.force is enabled
-		"for a in $argv[2..]",      // inspect CLI args
-		"case -y --yes --force",    // whitelist the force flags close understands
-		"case --no-yes --no-force", // ...and their negations
-		"--print-path $close_arg",  // forward only whitelisted flags to close
+		"$stderr_output[1]",       // worktree path
+		"$stderr_output[2..-1]",   // remaining lines = rm flags
+		"command gw rm $rm_flags", // forward the flags to gw rm
+		"--print-path $argv[2..]", // forward every user arg to gw close
 	}
 
 	for _, elem := range requiredElements {
 		if !containsString(fishInit, elem) {
-			t.Errorf("fishInit should contain %q to read the worktree path and -y flag separately", elem)
+			t.Errorf("fishInit should contain %q to read the worktree path and rm flags separately", elem)
 		}
 	}
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -93,6 +93,7 @@ func TestBashZshInit_ClosePathAndFlagSeparation(t *testing.T) {
 		"sed -n '3p'",                          // extract branch flag (line 3)
 		`command gw rm $yes_flag $branch_flag`, // forward the flags to gw rm
 		`--print-path "${@:2}"`,                // forward every user arg to gw close
+		`printf '%s\n' "$stderr_output" >&2`,   // surface close errors (issue #36 #1)
 	}
 
 	for _, elem := range requiredElements {
@@ -108,10 +109,11 @@ func TestBashZshInit_ClosePathAndFlagSeparation(t *testing.T) {
 // forwarded to `gw rm` (issue #36).
 func TestFishInit_ClosePathAndFlagSeparation(t *testing.T) {
 	requiredElements := []string{
-		"$stderr_output[1]",       // worktree path
-		"$stderr_output[2..-1]",   // remaining lines = rm flags
-		"command gw rm $rm_flags", // forward the flags to gw rm
-		"--print-path $argv[2..]", // forward every user arg to gw close
+		"$stderr_output[1]",             // worktree path
+		"$stderr_output[2..-1]",         // remaining lines = rm flags
+		"command gw rm $rm_flags",       // forward the flags to gw rm
+		"--print-path $argv[2..]",       // forward every user arg to gw close
+		"printf '%s\\n' $stderr_output", // surface close errors (issue #36 #1)
 	}
 
 	for _, elem := range requiredElements {


### PR DESCRIPTION
## 概要
README に記載されているが未実装だった `gw close` のブランチ削除系フラグを実装します（#36）。

- `gw close -b` / `gw close --branch` … worktree に加えて対応ブランチも削除
- `gw close -f -b` … 強制 close（未マージブランチも削除）
- `--force` に `-f` ショートハンドを追加（`--yes` のエイリアス）

削除ロジックは既存の `gw rm`（`-b/--branch`, `-f`）を再利用します。

## 実装方針
`close` はシェルラッパー経由で `gw rm` を呼ぶ構造のため、`close` が転送すべきフラグを **stderr の別々の行**（2行目=force, 3行目=branch）に出力し、bash/zsh/fish の各ラッパーがそれを `gw rm` に渡します。

各フラグを1行1トークンにしているのは、スペース連結した1変数を非クォート展開しても **zsh は既定で単語分割しない**ため（`gw rm "-y -b"` が1引数になって壊れる）。空変数・単一トークン変数はどちらのシェルでも安全に展開されます。

## ベース
本 PR は #34（`close` の force シェルラッパー修正）の上にスタックしています。ラッパーの stderr パース処理を #34 から引き継ぎ、`-b` 転送を追加しています。`base` は `fix/34-close-force-shell-wrapper`。

## 検証（実バイナリ + 実シェル）
bash / zsh / fish × フラグ無し / `-b`(merged) / `-b`(unmerged) / `-f -b`(unmerged) を実 git リポジトリで確認。全て期待通り:
- フラグ無し … worktree 削除・ブランチ保持
- `-b`（merged）… worktree + ブランチ削除
- `-b`（unmerged）… worktree 削除・ブランチ削除は安全に拒否（警告）
- `-f -b`（unmerged）… worktree + ブランチを強制削除
- `--print-path` プロトコル、フラグ競合（`-y --no-yes`）も確認

`go test -race ./...` / `golangci-lint`（変更ファイルは指摘なし）通過。

Closes #36