### PR TITLE
docs: 設定項目 add.from を README に追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ editor: code  # Editor command to use
 - `add.open` (boolean): Whether to automatically open in editor after worktree creation (default: `false`)
 - `add.sync` (boolean): Whether to sync files from main worktree (default: `false`)
 - `add.sync_ignored` (boolean): Whether to also sync gitignored files (default: `false`)
+- `add.from` (string): Base branch/commit used when creating a new branch with the `-b` flag (e.g., `origin/main`, `develop`, `HEAD~1`). The command-line argument takes precedence over this value (default: `""` - uses current branch)
 - `rm.branch` (boolean): Whether to also delete associated branch when removing worktree (default: `false`)
 - `rm.force` (boolean): Whether to skip confirmation prompt when deleting (default: `false`)
 - `close.force` (boolean): Whether to skip confirmation prompt when closing (default: `false`)


### PR DESCRIPTION
## 概要
設定項目 \`add.from\` が実装（\`internal/config/config.go\` の \`AddConfig.From\`）・\`examples/config.yaml\` には存在するが、README の User Configuration 節「Configuration Items」一覧に未記載だったため追記する。

## 変更内容
- README の Configuration Items に \`add.from\`（string）を追加
  - \`-b\` フラグで新規ブランチ作成時のベース branch/commit を指定
  - CLI 引数（位置引数 \`[from]\`）がこの設定値より優先（\`cmd/add.go:183-184\`）
  - デフォルトは空文字＝現在ブランチ起点

## 動作確認
- ドキュメントのみの変更
- 記述内容を実装と突き合わせて確認済み
  - \`-b\` フラグ: \`cmd/add.go:82\`
  - CLI 引数優先: \`cmd/add.go:183-184\`（位置引数が空のとき config を使用）
  - \`from\` は新規ブランチ作成時のみ適用: \`cmd/add.go:67\`

Closes #40