### PR TITLE
feat: --sync と --sync-ignored を併用可能にする (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ gw add invalid-branch
 ```yaml
 add:
   open: true  # Automatically open in editor after worktree creation
-  sync: false  # Sync files from main worktree
-  sync_ignored: false  # Also sync gitignored files
+  sync: false  # Sync changed files from main worktree (excludes gitignored)
+  sync_ignored: false  # Also sync gitignored files (can be combined with sync)
 rm:
   branch: false  # Also delete branch when removing worktree
   force: false  # Skip confirmation prompt
@@ -286,8 +286,8 @@ editor: code  # Editor command to use
 #### Configuration Items
 
 - `add.open` (boolean): Whether to automatically open in editor after worktree creation (default: `false`)
-- `add.sync` (boolean): Whether to sync files from main worktree (default: `false`)
-- `add.sync_ignored` (boolean): Whether to also sync gitignored files (default: `false`)
+- `add.sync` (boolean): Whether to sync changed files (modified, staged, untracked; excludes gitignored) from main worktree (default: `false`)
+- `add.sync_ignored` (boolean): Whether to also sync gitignored files (default: `false`). Independent of `add.sync`; enabling both syncs changed files **and** gitignored files.
 - `add.from` (string): Base branch/commit used when creating a new branch with the `-b` flag (e.g., `origin/main`, `develop`, `HEAD~1`). The command-line argument takes precedence over this value (default: `""` - uses current branch)
 - `rm.branch` (boolean): Whether to also delete associated branch when removing worktree (default: `false`)
 - `rm.force` (boolean): Whether to skip confirmation prompt when deleting (default: `false`)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -102,9 +102,6 @@ func runAddWithSelector(cmd *cobra.Command, args []string, selector fzf.Selector
 	if flagAddBranch && flagAddPR != "" {
 		return fmt.Errorf("cannot use --branch and --pr together")
 	}
-	if flagSyncAll && flagSyncIgnored {
-		return fmt.Errorf("cannot use --sync and --sync-ignored together")
-	}
 
 	// Validate --no-* flag conflicts
 	if flagAddOpen && flagNoOpen {
@@ -126,11 +123,11 @@ func runAddWithSelector(cmd *cobra.Command, args []string, selector fzf.Selector
 	if cmd.Flags().Changed("editor") {
 		editorFlagPtr = &flagEditor
 	}
+	// --sync and --sync-ignored are independent; each overrides only its own
+	// config value so the two can be combined.
 	var syncFlagPtr *bool
-	if cmd.Flags().Changed("sync") || cmd.Flags().Changed("sync-ignored") {
-		// If either flag is set, determine sync behavior
-		syncEnabled := flagSyncAll
-		syncFlagPtr = &syncEnabled
+	if cmd.Flags().Changed("sync") {
+		syncFlagPtr = &flagSyncAll
 	}
 	var syncIgnoredFlagPtr *bool
 	if cmd.Flags().Changed("sync-ignored") {
@@ -213,7 +210,7 @@ func runAddWithSelector(cmd *cobra.Command, args []string, selector fzf.Selector
 	editorCmd := mergedConfig.GetEditor()
 
 	// Determine sync mode
-	syncMode := determineSyncMode(mergedConfig.Add.Sync, mergedConfig.Add.SyncIgnored, flagSyncAll, flagSyncIgnored)
+	syncMode := determineSyncMode(mergedConfig.Add.Sync, mergedConfig.Add.SyncIgnored)
 
 	// Create the worktree
 	return createWorktree(repoName, branch, flagAddBranch, from, editorCmd, syncMode)

--- a/cmd/add_helpers.go
+++ b/cmd/add_helpers.go
@@ -14,13 +14,15 @@ import (
 	"github.com/t98o84/gw/internal/github"
 )
 
-// syncMode represents the synchronization mode for worktree creation
+// syncMode is a bitmask of the file categories to synchronize when creating a
+// worktree. syncAll and syncIgnored cover disjoint file sets, so they can be
+// combined to sync both changed and gitignored files at once.
 type syncMode int
 
 const (
-	syncNone syncMode = iota
-	syncAll
-	syncIgnored
+	syncNone    syncMode = 0
+	syncAll     syncMode = 1 << 0 // changed files: modified, staged, untracked (excludes ignored)
+	syncIgnored syncMode = 1 << 1 // gitignored files
 )
 
 // Mock functions for testing - nil in production
@@ -171,14 +173,17 @@ func syncFiles(wtPath string, mode syncMode) error {
 		return fmt.Errorf("failed to get main worktree path: %w", err)
 	}
 
-	switch mode {
-	case syncAll:
-		return syncAllDiffs(mainWtPath, wtPath)
-	case syncIgnored:
-		return syncIgnoredFiles(mainWtPath, wtPath)
-	default:
-		return nil
+	if mode&syncAll != 0 {
+		if err := syncAllDiffs(mainWtPath, wtPath); err != nil {
+			return err
+		}
 	}
+	if mode&syncIgnored != 0 {
+		if err := syncIgnoredFiles(mainWtPath, wtPath); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // getMainWorktreePath returns the path of the main worktree
@@ -291,21 +296,18 @@ func copyFile(src, dst string) error {
 	return nil
 }
 
-// determineSyncMode determines which sync mode to use
-func determineSyncMode(configSync, configSyncIgnored, flagSyncAll, flagSyncIgnored bool) syncMode {
-	if flagSyncAll {
-		return syncAll
+// determineSyncMode builds the sync bitmask from the resolved sync settings.
+// The two options are independent: enabling both syncs changed and gitignored
+// files together.
+func determineSyncMode(sync, ignored bool) syncMode {
+	mode := syncNone
+	if sync {
+		mode |= syncAll
 	}
-	if flagSyncIgnored {
-		return syncIgnored
+	if ignored {
+		mode |= syncIgnored
 	}
-	if configSync {
-		return syncAll
-	}
-	if configSyncIgnored {
-		return syncIgnored
-	}
-	return syncNone
+	return mode
 }
 
 // createWorktree creates a new worktree for the given branch

--- a/cmd/add_helpers_test.go
+++ b/cmd/add_helpers_test.go
@@ -659,6 +659,30 @@ func TestEnsureBranchExists(t *testing.T) {
 	}
 }
 
+// TestDetermineSyncMode verifies that the resolved sync settings map to the
+// expected bitmask, including the combined case where both are enabled.
+func TestDetermineSyncMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		sync    bool
+		ignored bool
+		want    syncMode
+	}{
+		{name: "neither", sync: false, ignored: false, want: syncNone},
+		{name: "changed files only", sync: true, ignored: false, want: syncAll},
+		{name: "ignored files only", sync: false, ignored: true, want: syncIgnored},
+		{name: "both combined", sync: true, ignored: true, want: syncAll | syncIgnored},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := determineSyncMode(tt.sync, tt.ignored); got != tt.want {
+				t.Errorf("determineSyncMode(%v, %v) = %d, want %d", tt.sync, tt.ignored, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestCreateWorktree tests the createWorktree function
 func TestCreateWorktree(t *testing.T) {
 	tests := []struct {

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -9,14 +9,17 @@ add:
   # Default: false
   open: true
 
-  # Synchronize all changed files from main worktree when creating a new worktree
-  # When true, all files with differences (modified, staged, untracked) will be copied
+  # Synchronize changed files from main worktree when creating a new worktree
+  # When true, all files with differences (modified, staged, untracked) will be
+  # copied. Gitignored files are NOT included here (see sync_ignored below).
   # Use --sync/-s flag to explicitly enable this
   # Default: false
   sync: false
 
   # Synchronize gitignored files from main worktree when creating a new worktree
   # When true, gitignored files will be copied to the new worktree
+  # This is independent of `sync`: enabling both copies changed files AND
+  # gitignored files (the two sets do not overlap)
   # Use --sync-ignored/-i flag to explicitly enable this
   # Default: false
   sync_ignored: false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -556,6 +556,83 @@ func TestConfig_MergeWithFlags_From(t *testing.T) {
 	}
 }
 
+func TestConfig_MergeWithFlags_Sync(t *testing.T) {
+	// sync and sync_ignored are independent: a flag for one must not clobber
+	// the config value of the other. This guards the regression where passing
+	// --sync-ignored alone used to force Add.Sync back to false.
+	tests := []struct {
+		name              string
+		config            *Config
+		syncFlag          *bool
+		syncIgnoredFlag   *bool
+		noSyncFlag        bool
+		noSyncIgnoredFlag bool
+		wantSync          bool
+		wantSyncIgnored   bool
+	}{
+		{
+			name:            "sync-ignored flag alone keeps config sync",
+			config:          &Config{Add: AddConfig{Sync: true, SyncIgnored: false}},
+			syncFlag:        nil, // --sync not passed
+			syncIgnoredFlag: boolPtr(true),
+			wantSync:        true, // must NOT be clobbered to false
+			wantSyncIgnored: true,
+		},
+		{
+			name:            "sync flag alone keeps config sync_ignored",
+			config:          &Config{Add: AddConfig{Sync: false, SyncIgnored: true}},
+			syncFlag:        boolPtr(true),
+			syncIgnoredFlag: nil, // --sync-ignored not passed
+			wantSync:        true,
+			wantSyncIgnored: true,
+		},
+		{
+			name:            "both flags enable both",
+			config:          &Config{Add: AddConfig{Sync: false, SyncIgnored: false}},
+			syncFlag:        boolPtr(true),
+			syncIgnoredFlag: boolPtr(true),
+			wantSync:        true,
+			wantSyncIgnored: true,
+		},
+		{
+			name:              "no-sync-ignored disables only sync_ignored",
+			config:            &Config{Add: AddConfig{Sync: true, SyncIgnored: true}},
+			syncFlag:          nil,
+			syncIgnoredFlag:   nil,
+			noSyncIgnoredFlag: true,
+			wantSync:          true,
+			wantSyncIgnored:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged := tt.config.MergeWithFlags(
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				tt.syncFlag,
+				tt.syncIgnoredFlag,
+				nil,
+				false,
+				tt.noSyncFlag,
+				tt.noSyncIgnoredFlag,
+				false,
+				false,
+				false,
+			)
+			if merged.Add.Sync != tt.wantSync {
+				t.Errorf("MergeWithFlags() Add.Sync = %v, want %v", merged.Add.Sync, tt.wantSync)
+			}
+			if merged.Add.SyncIgnored != tt.wantSyncIgnored {
+				t.Errorf("MergeWithFlags() Add.SyncIgnored = %v, want %v", merged.Add.SyncIgnored, tt.wantSyncIgnored)
+			}
+		})
+	}
+}
+
 func TestConfig_GetEditor(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/skills/gw/SKILL.md
+++ b/skills/gw/SKILL.md
@@ -77,11 +77,12 @@ Flags:
 - `-e, --editor <cmd>` — editor command (e.g. `code`, `vim`). Auto-open also requires
   `add.open=true` (or `--open`).
 - `-s, --sync` — copy all changed files (modified/staged/untracked) from the main worktree.
-- `-i, --sync-ignored` — copy gitignored files from the main worktree.
+- `-i, --sync-ignored` — copy gitignored files from the main worktree. Independent of
+  `-s`; combine `-s -i` to copy both changed and gitignored files.
 - `--no-open`, `--no-sync`, `--no-sync-ignored` — force-disable the matching option even
   if enabled in config (see "Config precedence").
 
-Mutually exclusive (error if combined): `-b`+`-p`, `-s`+`-i`, and each `--x`+`--no-x` pair.
+Mutually exclusive (error if combined): `-b`+`-p`, and each `--x`+`--no-x` pair.
 
 Behavior notes:
 


### PR DESCRIPTION
## 概要
Closes #41

`--sync`(-s) と `--sync-ignored`(-i) はこれまで排他で、同時指定は `cannot use --sync and --sync-ignored together` エラーになっていた。一方 README / `examples/config.yaml` は `sync_ignored` を「**also** sync gitignored files」と追加的に表現しており、実装と食い違っていた（#41）。

方針は Issue の2案のうち「**両方同期できるようにする**」を採用（ユーザー確認済み）。これにより「also」表現も実装と整合する。

## 背景（なぜ安全に両立できるか）
同期対象の集合は元々分離している:
- `sync` → `git status --porcelain`（modified/staged/untracked、**ignored 非含**）
- `sync_ignored` → `git ls-files --others --ignored --exclude-standard`（**ignored のみ**）

両集合は重複しないため、順次コピーしても二重コピーは起きない。

## 変更内容
- `cmd/add_helpers.go`
  - `syncMode` を排他 enum → **ビットマスク**（`syncAll=1<<0`, `syncIgnored=1<<1`）に変更
  - `syncFiles` を `switch` → `if mode&bit != 0` の bitwise 判定へ。両方立てば両集合をコピー
  - `determineSyncMode` を2つの bool → ビットマスクを返す純関数に簡素化
- `cmd/add.go`
  - 併用エラーガード（`cannot use --sync and --sync-ignored together`）を削除
  - `-s`/`-i` が各自の config 値のみ上書きするよう修正（従来 `-i` 指定が config の `sync:true` を潰す副作用を解消）
- ドキュメント（`README.md` / `examples/config.yaml` / `skills/gw/SKILL.md`）を実装に合わせ更新（独立・併用可を明記、SKILL.md の "mutually exclusive: -s+-i" を削除）
- `cmd/add_helpers_test.go`: `determineSyncMode` のテーブルテストを追加（none / -s / -i / 併用 の4通り）

## 検証
- `go build ./...` / `go vet ./...` / `go test -race ./...` すべて PASS
- `gofmt -l` 差分なし
- 実バイナリでスモークテスト（一時 git リポジトリ）:

| コマンド | tracked(変更) | untracked | ignored |
|---|---|---|---|
| `gw add -b -s -i` | ✅同期 | ✅同期 | ✅同期 |
| `gw add -b -s` | ✅同期 | ✅同期 | 非同期 |
| `gw add -b -i` | 非同期 | 非同期 | ✅同期 |
| `gw add -b` | 非同期 | 非同期 | 非同期 |

併用（新機能）で3種すべて同期、単独時の挙動は不変（リグレッションなし）を確認。