### PR TITLE
docs: cmd 一覧を実体と一致させ close.go 等の記載漏れを追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,49 @@ gw/
 └── compose.yaml
 ```
 
+## Shell Integration
+
+`gw sw` and `gw close` must change the **parent shell's** working directory,
+which a child process cannot do on its own. `gw init <shell>` therefore emits a
+`gw()` wrapper function that runs the real binary, reads the path it prints, and
+`cd`s the shell itself (see `cmd/init.go`).
+
+### Supported shells
+
+| Shell | `gw init` arg | Setup |
+|-------|---------------|-------|
+| bash  | `bash` | `eval "$(gw init bash)"` in `~/.bashrc` |
+| zsh   | `zsh`  | `eval "$(gw init zsh)"` in `~/.zshrc` |
+| fish  | `fish` | `gw init fish \| source` in `~/.config/fish/config.fish` |
+
+POSIX `sh`/dash is **not** supported: the shared wrapper uses `${@:2}` array
+slicing, a bash/zsh extension that `sh` cannot run. `runInit` returns
+`unsupported shell` for anything other than the three above.
+
+### Per-shell syntax caveats
+
+When editing the embedded scripts in `cmd/init.go`, keep these in mind:
+
+- **bash and zsh share one script** (`bashZshInit`). Use only syntax valid in
+  both: POSIX `[ ... ]` tests plus `${@:2}` array slicing (valid in bash and
+  zsh, not in sh).
+- **The wrapper receives paths over stdout/stderr, not arguments.**
+  `gw close --print-path` prints the main-worktree path on **stdout** (for the
+  wrapper to `cd`) and the current-worktree path on the **first stderr line**
+  (for `gw rm`); a **second stderr line** carries `-y` (or is empty). Keep
+  stdout and stderr separated when editing.
+- **fish uses a separate script** (`fishInit`) with different syntax:
+  `function ... end`, `$argv`, `set -l`, `; and`. It parses both stderr lines
+  with `sed -n '1p'`/`'2p'` and forwards `-y` to `gw rm`; the bash/zsh script
+  currently reads only the worktree path. A change on one side usually needs a
+  mirrored change on the other.
+- **Mind the bash vs zsh word-splitting difference** when changing how these
+  captured values are passed on: an unquoted expansion is word-split in bash
+  but not in zsh, so the shared script must not rely on that behaviour.
+
+To add a shell, add a `case` in `runInit` (`cmd/init.go`) and a matching
+integration-script constant.
+
 ## Coding Conventions
 
 ### Language

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,18 +13,21 @@ This document provides guidelines for AI agents (GitHub Copilot, Claude, etc.) w
 docker compose run --rm dev sh
 
 # Or execute commands directly
-docker compose run --rm dev go test ./...
+docker compose run --rm dev go test -race ./...
 docker compose run --rm dev go build -o gw .
 ```
 
 ### Command Examples
 
 ```bash
-# Run tests
-docker compose run --rm dev go test ./...
+# Run tests (race detector, matches CI)
+docker compose run --rm dev go test -race ./...
 
 # Detailed test output
-docker compose run --rm dev go test ./... -v
+docker compose run --rm dev go test -race ./... -v
+
+# Vet
+docker compose run --rm dev go vet ./...
 
 # Build (for Linux)
 docker compose run --rm dev go build -o gw .
@@ -64,8 +67,21 @@ gw/
 │   ├── git/             # Git operations
 │   │   ├── worktree.go  # git worktree operations
 │   │   └── naming.go    # Naming convention conversion
-│   └── github/          # GitHub API
-│       └── pr.go        # Get branch from PR
+│   ├── github/          # GitHub API
+│   │   └── pr.go        # Get branch from PR
+│   ├── config/          # Configuration and hooks
+│   │   ├── config.go    # Config types and flag merge
+│   │   ├── loader.go    # Load config from files (Load)
+│   │   ├── hooks.go     # Hook types and execution (post_add, pre_remove, ...)
+│   │   ├── project.go   # Project config from gw.yaml
+│   │   └── path.go      # Config file path resolution
+│   ├── shell/           # External command execution
+│   │   ├── executor.go  # Executor interface + real implementation
+│   │   └── mock.go      # Executor mock for tests
+│   ├── errors/          # Typed domain errors
+│   │   └── errors.go    # Error types (BranchNotFoundError, ...)
+│   └── fzf/             # fzf integration
+│       └── selector.go  # Selector interface for interactive choice
 ├── go.mod
 ├── go.sum
 ├── Dockerfile
@@ -135,11 +151,14 @@ integration-script constant.
 ## Dependencies
 
 - [github.com/spf13/cobra](https://github.com/spf13/cobra) - CLI framework
-- [github.com/google/go-github](https://github.com/google/go-github) - GitHub API client
+- [github.com/google/go-github/v66](https://github.com/google/go-github) - GitHub API client
 - [golang.org/x/oauth2](https://pkg.go.dev/golang.org/x/oauth2) - OAuth2 authentication
+- [gopkg.in/yaml.v3](https://gopkg.in/yaml.v3) - YAML parsing (config files)
 
 ## Notes
 
 1. **fzf-related tests**: Do not directly call fzf in tests as it requires interactive input
 2. **git commands**: Execute through the `internal/git` package. Tests may run outside a git repository
 3. **GitHub API**: Use `GITHUB_TOKEN`, `GH_TOKEN` environment variables, or `gh auth token` for authentication
+4. **Linting**: CI runs `golangci-lint` (default config) and `go vet` on every PR. `golangci-lint` is **not** bundled in the dev image (it only has `git` and `fzf`); install it locally (see the golangci-lint docs) and run `golangci-lint run` before pushing to avoid CI lint failures.
+5. **Configuration**: User/project config and hooks live in `internal/config`. See `examples/config.yaml` and `examples/gw.yaml` for the format; hooks such as `post_add`/`pre_remove` are documented in the README.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ integration-script constant.
 
 ### Language
 - Code comments: English
-- Commit messages: English
+- Commit messages: [Conventional Commits](https://www.conventionalcommits.org/). The type prefix (`feat:`/`fix:`/`docs:`, ...) must be English—git-cliff parses it for the CHANGELOG (see `.cliff.toml` and `.github/RELEASE_PROCESS.md` for the type list). The description and body may be Japanese or English.
 - Documentation (README, etc.): English
 
 ### Style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,13 @@ gw/
 │   ├── rm.go            # gw rm - Remove worktree (multiple selection support)
 │   ├── ls.go            # gw ls - List worktrees
 │   ├── sw.go            # gw sw - Switch worktree
+│   ├── close.go         # gw close - Close current worktree and switch to main
 │   ├── exec.go          # gw exec - Execute command in worktree
 │   ├── fd.go            # gw fd - Search worktree with fzf
 │   ├── init.go          # gw init - Output shell integration script
-│   └── fzf.go           # fzf helper functions
+│   ├── fzf.go           # fzf helper functions
+│   ├── add_helpers.go   # gw add helper functions
+│   └── config.go        # Command flag configuration
 ├── internal/
 │   ├── git/             # Git operations
 │   │   ├── worktree.go  # git worktree operations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,9 @@ gw/
 │   ├── fd.go            # gw fd command
 │   ├── init.go          # gw init command
 │   ├── close.go         # gw close command
-│   └── fzf.go           # fzf helper functions
+│   ├── fzf.go           # fzf helper functions
+│   ├── add_helpers.go   # gw add helper functions
+│   └── config.go        # Command flag configuration
 ├── internal/
 │   ├── git/             # Git operations
 │   ├── github/          # GitHub API


### PR DESCRIPTION
## 概要
`AGENTS.md` の記載を実体（コード / CI / go.mod / changelog 設定）に一致させる。起点は issue #42（`cmd/` 一覧の `close.go` 記載漏れ）で、監査で見つかった同種のドリフトもまとめて是正した。

## 変更内容
### 1. cmd 一覧を実体と一致（#42 本体）
`close.go` に加え未記載だった `config.go` / `add_helpers.go` を追記し `cmd/` と完全一致。`CONTRIBUTING.md` も同様に整備。

### 2. Shell Integration 節を新設
対応シェル（bash/zsh/fish、`sh` 非対応）と `cmd/init.go` 編集時の構文注意点（bash/zsh 共用 vs fish 別スクリプト、`gw close` の stdout/stderr チャネル設計、bash/zsh の単語分割差）。現行 main では `-y` 転送が fish のみである点も明記。

### 3. コード/CI/go.mod との乖離を是正
- **Project Structure の `internal/` 一覧**：`config/` `shell/` `errors/` `fzf/` を追記（4パッケージ欠落、#42 と同種のドリフト）
- **テストコマンド**：CI と揃え `go test -race ./...` に修正、`go vet` を追加
- **golangci-lint**：CI が強制するのに未記載だったため Notes に明記（dev イメージ非同梱＝要ローカル導入の注意付き）
- **設定システム**：`internal/config` + `examples/` を Notes に追記
- **Dependencies**：直接依存の `gopkg.in/yaml.v3` を追記、`go-github` を `/v66` 表記に

### 4. コミットメッセージ規約を実態に合わせて精密化
`Commit messages: English` の丸ごと英語要求を是正。技術的制約は git-cliff（`.cliff.toml` `conventional_commits=true`）が **type prefix をパースする点のみ**で、散文まで英語にする根拠はない。**type（`feat:`/`fix:`/`docs:` 等）は英語必須、件名・本文は日本語可**、と精密化。type 一覧は再掲せず `RELEASE_PROCESS.md` / `.cliff.toml` を参照（SSoT 一元化）。`CONTRIBUTING.md`/`RELEASE_PROCESS.md` は元々英語強制していないため変更不要。

## 検証
- `cmd/*.go` / `internal/**`（`_test.go` 除外）と両ドキュメント一覧を突き合わせ、過不足ゼロを確認。
- シェル・チャネル設計・依存・CI コマンド・changelog 規約の記述はすべて `cmd/init.go` `cmd/close.go` `ci.yaml` `go.mod` `Dockerfile` `.cliff.toml` の現行コードで裏取り済み。

Closes #42