### PR TITLE
ci: テストカバレッジの閾値ゲートで必須化

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,25 @@ jobs:
       - name: Run tests
         run: go test -race -coverprofile=coverage.txt ./...
 
+      # カバレッジ必須化のゲート。
+      # 総ステートメントカバレッジが COVERAGE_THRESHOLD 未満なら CI を失敗させる。
+      # この test ジョブは main のブランチ保護で必須チェックに設定されているため、
+      # 下回った PR はマージできない。
+      #
+      # 現状はおよそ 50% を下限としてラチェット（後退防止）している。
+      # 今後テストを追加しながら COVERAGE_THRESHOLD を段階的に引き上げ、
+      # 最終的に 100% を目指す。カバレッジが上がったらこの値も忘れず上げること。
+      - name: Enforce coverage threshold
+        env:
+          COVERAGE_THRESHOLD: '50'
+        run: |
+          total=$(go tool cover -func=coverage.txt | awk '/^total:/ {print $3}' | tr -d '%')
+          echo "Total coverage: ${total}% (threshold: ${COVERAGE_THRESHOLD}%)"
+          if awk -v cur="$total" -v th="$COVERAGE_THRESHOLD" 'BEGIN { exit (cur+0 < th+0) ? 0 : 1 }'; then
+            echo "::error::Total coverage ${total}% is below the required threshold of ${COVERAGE_THRESHOLD}%"
+            exit 1
+          fi
+
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,15 @@ jobs:
       - name: Run tests
         run: go test -race -coverprofile=coverage.txt ./...
 
+      # カバレッジは閾値ゲートで失敗させる前にアップロードしておく。
+      # こうすることで閾値割れで CI が落ちた実行でも codecov に履歴が残り、
+      # カバレッジの推移を追える。
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.txt
+        continue-on-error: true
+
       # カバレッジ必須化のゲート。
       # 総ステートメントカバレッジが COVERAGE_THRESHOLD 未満なら CI を失敗させる。
       # この test ジョブは main のブランチ保護で必須チェックに設定されているため、
@@ -43,12 +52,6 @@ jobs:
             echo "::error::Total coverage ${total}% is below the required threshold of ${COVERAGE_THRESHOLD}%"
             exit 1
           fi
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: coverage.txt
-        continue-on-error: true
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

CI の `test` ジョブにカバレッジ閾値ゲートを追加し、テストカバレッジを必須化する。

## 背景

これまで `test` ジョブは coverage を codecov にアップロードするだけで、`continue-on-error: true` のため**カバレッジは強制されていなかった**。一方 `main` のブランチ保護では `test` が必須チェックに設定済み。そこで `test` ジョブ内に閾値ゲートを仕込むことで、ブランチ保護を変更せずに必須化できる。

## 変更内容

- `go test` の後に総ステートメントカバレッジを算出し、`COVERAGE_THRESHOLD`（現状 `50`）未満なら `exit 1` するステップを追加
- 閾値割れの PR は必須チェック `test` が失敗し、マージ不可となる

## 方針

- 現状の総カバレッジは約 51%。まず **50% を下限としたラチェット**（後退防止）から開始
- 今後テストを追加しながら `COVERAGE_THRESHOLD` を段階的に引き上げ、**最終的に 100% を目指す**（コメントに明記）

## 検証

- ゲートのロジックを実測確認: 閾値 50 → PASS / 51（等値）→ PASS / 100 → FAIL
- `actionlint`（shellcheck 含む）exit 0
- インジェクション対策: 閾値は静的リテラルを env 経由で渡し、比較には信頼できる `go tool cover` 出力のみ使用